### PR TITLE
fix off by one bug in cc_ring_array

### DIFF
--- a/src/cc_ring_array.c
+++ b/src/cc_ring_array.c
@@ -77,7 +77,7 @@ ring_array_nelem(uint32_t rpos, uint32_t wpos, uint32_t cap)
     if (rpos <= wpos) { /* condition 1), 2) */
         return wpos - rpos;
     } else {            /* condition 3) */
-        return wpos + (cap - wpos + 1);
+        return wpos + (cap - rpos + 1);
     }
 }
 


### PR DESCRIPTION
This patch fixes the bug @seppo0010 pointed out in #53. What was happening before was that instead of filling up the array where rpos == 0 and wpos == cap, since we did wpos = (wpos + 1) % cap, this skips the "array is full" condition and moves straight to the array being empty, hence pushing cap + 1 elements wrongly succeeded. To correct this behavior, we simply % cap + 1 instead, which leads to the desired behavior. Thanks @seppo0010 for pointing this out!
