### PR TITLE
tcp writev/recvv refactoring

### DIFF
--- a/include/channel/cc_tcp.h
+++ b/include/channel/cc_tcp.h
@@ -127,7 +127,7 @@ bool tcp_listen(struct addrinfo *ai, struct tcp_conn *c);   /* channel_open_fn, 
 void tcp_close(struct tcp_conn *c);                         /* channel_perm_fn */
 ssize_t tcp_recv(struct tcp_conn *c, void *buf, size_t nbyte); /* channel_recv_fn */
 ssize_t tcp_send(struct tcp_conn *c, void *buf, size_t nbyte); /* channel_send_fn */
-ssize_t tcp_recvv(struct tcp_conn *c, struct array *bufv, size_t nbyte);
+ssize_t tcp_recvv(struct tcp_conn *c, struct array *bufv);
 ssize_t tcp_sendv(struct tcp_conn *c, struct array *bufv);
 
 bool tcp_accept(struct tcp_conn *sc, struct tcp_conn *c);   /* channel_accept_fn */

--- a/include/channel/cc_tcp.h
+++ b/include/channel/cc_tcp.h
@@ -128,7 +128,7 @@ void tcp_close(struct tcp_conn *c);                         /* channel_perm_fn *
 ssize_t tcp_recv(struct tcp_conn *c, void *buf, size_t nbyte); /* channel_recv_fn */
 ssize_t tcp_send(struct tcp_conn *c, void *buf, size_t nbyte); /* channel_send_fn */
 ssize_t tcp_recvv(struct tcp_conn *c, struct array *bufv, size_t nbyte);
-ssize_t tcp_sendv(struct tcp_conn *c, struct array *bufv, size_t nbyte);
+ssize_t tcp_sendv(struct tcp_conn *c, struct array *bufv);
 
 bool tcp_accept(struct tcp_conn *sc, struct tcp_conn *c);   /* channel_accept_fn */
 void tcp_reject(struct tcp_conn *sc);                   /* channel_reject_fn */

--- a/src/channel/cc_tcp.c
+++ b/src/channel/cc_tcp.c
@@ -686,8 +686,6 @@ _tcp_recvv(struct tcp_conn *c, const struct iovec *iov, int iovcnt)
 ssize_t
 tcp_recv(struct tcp_conn *c, void *buf, size_t nbyte)
 {
-    ssize_t n;
-
     ASSERT(buf != NULL);
     ASSERT(nbyte > 0);
 

--- a/src/channel/cc_tcp.c
+++ b/src/channel/cc_tcp.c
@@ -701,7 +701,7 @@ tcp_recv(struct tcp_conn *c, void *buf, size_t nbyte)
  * vector version of tcp_recv, using readv to read into a mbuf array
  */
 ssize_t
-tcp_recvv(struct tcp_conn *c, struct array *bufv, size_t nbyte)
+tcp_recvv(struct tcp_conn *c, struct array *bufv)
 {
     ASSERT(array_nelem(bufv) > 0);
 

--- a/src/channel/cc_tcp.c
+++ b/src/channel/cc_tcp.c
@@ -624,88 +624,29 @@ tcp_get_soerror(int sd)
     return status;
 }
 
-
-/*
- * try reading nbyte bytes from tcp_conn and place the data in buf
- * EINTR is continued, EAGAIN is explicitly flagged in return, other errors are
- * returned as a generic error/failure.
- */
-ssize_t
-tcp_recv(struct tcp_conn *c, void *buf, size_t nbyte)
+static ssize_t
+_tcp_recvv(struct tcp_conn *c, const struct iovec *iov, int iovcnt)
 {
     ssize_t n;
+    int i;
+    size_t nbyte = 0;
 
-    ASSERT(buf != NULL);
-    ASSERT(nbyte > 0);
-
-    log_verb("recv on sd %d, capacity %zu bytes", c->sd, nbyte);
-
-    for (;;) {
-        n = read(c->sd, buf, nbyte);
-        INCR(tcp_metrics, tcp_recv);
-
-        log_verb("read on sd %d %zd of %zu", c->sd, n, nbyte);
-
-        if (n > 0) {
-            log_verb("%zu bytes recv'd on sd %d", n, c->sd);
-            c->recv_nbyte += (size_t)n;
-            INCR_N(tcp_metrics, tcp_recv_byte, n);
-            return n;
-        }
-
-        if (n == 0) {
-            c->state = CHANNEL_TERM;
-            log_debug("eof recv'd on sd %d, total: rb %zu sb %zu", c->sd,
-                      c->recv_nbyte, c->send_nbyte);
-            return n;
-        }
-
-        /* n < 0 */
-        INCR(tcp_metrics, tcp_recv_ex);
-        if (errno == EINTR) {
-            log_debug("recv on sd %d not ready - EINTR", c->sd);
-            continue;
-        } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            log_debug("recv on sd %d not ready - EAGAIN", c->sd);
-            return CC_EAGAIN;
-        } else {
-            c->err = errno;
-            log_error("recv on sd %d failed: %s", c->sd, strerror(errno));
-            return CC_ERROR;
-        }
+    for (i = 0; i < iovcnt; i++) {
+        nbyte += iov[i].iov_len;
     }
-
-    NOT_REACHED();
-
-    return CC_ERROR;
-}
-
-/*
- * vector version of tcp_recv, using readv to read into a mbuf array
- */
-ssize_t
-tcp_recvv(struct tcp_conn *c, struct array *bufv, size_t nbyte)
-{
-    /* TODO(yao): this is almost identical with tcp_recv except for the call
-     * to readv. Consolidate the two?
-     */
-    ssize_t n;
-
-    ASSERT(array_nelem(bufv) > 0);
-    ASSERT(nbyte != 0);
 
     log_verb("recvv on sd %d, total %zu bytes", c->sd, nbyte);
 
     for (;;) {
-        n = readv(c->sd, (const struct iovec *)bufv->data, bufv->nelem);
+        n = readv(c->sd, iov, iovcnt);
         INCR(tcp_metrics, tcp_recv);
 
         log_verb("recvv on sd %d %zd of %zu in %"PRIu32" buffers",
-                  c->sd, n, nbyte, bufv->nelem);
+                  c->sd, n, nbyte, iovcnt);
 
         if (n > 0) {
             c->recv_nbyte += (size_t)n;
-            INCR_N(tcp_metrics, tcp_recv, n);
+            INCR_N(tcp_metrics, tcp_recv_byte, n);
             return n;
         }
 
@@ -737,16 +678,54 @@ tcp_recvv(struct tcp_conn *c, struct array *bufv, size_t nbyte)
     return CC_ERROR;
 }
 
+/*
+ * try reading nbyte bytes from tcp_conn and place the data in buf
+ * EINTR is continued, EAGAIN is explicitly flagged in return, other errors are
+ * returned as a generic error/failure.
+ */
+ssize_t
+tcp_recv(struct tcp_conn *c, void *buf, size_t nbyte)
+{
+    ssize_t n;
+
+    ASSERT(buf != NULL);
+    ASSERT(nbyte > 0);
+
+    struct iovec iov;
+    iov.iov_base = buf;
+    iov.iov_len = nbyte;
+    return _tcp_recvv(c, &iov, 1);
+}
+
+/*
+ * vector version of tcp_recv, using readv to read into a mbuf array
+ */
+ssize_t
+tcp_recvv(struct tcp_conn *c, struct array *bufv, size_t nbyte)
+{
+    ASSERT(array_nelem(bufv) > 0);
+
+    return _tcp_recvv(c, (const struct iovec *)bufv->data, bufv->nelem);
+}
+
 static ssize_t
 _tcp_sendv(struct tcp_conn *c, const struct iovec *iov, int iovcnt)
 {
     ssize_t n;
+    int i;
+    size_t nbyte = 0;
+
+    for (i = 0; i < iovcnt; i++) {
+        nbyte += iov[i].iov_len;
+    }
+
+    log_verb("sendv on sd %d, total %zu bytes", c->sd, nbyte);
 
     for (;;) {
         n = writev(c->sd, iov, iovcnt);
         INCR(tcp_metrics, tcp_send);
 
-        log_verb("write on sd %d %zd of %zu", c->sd, n, iovcnt);
+        log_verb("sendv on sd %d %zd of %zu", c->sd, n, nbyte);
 
         if (n > 0) {
             INCR_N(tcp_metrics, tcp_send_byte, n);
@@ -755,21 +734,21 @@ _tcp_sendv(struct tcp_conn *c, const struct iovec *iov, int iovcnt)
         }
 
         if (n == 0) {
-            log_warn("write on sd %d returned zero", c->sd);
+            log_warn("sendv on sd %d returned zero", c->sd);
             return 0;
         }
 
         /* n < 0 */
         INCR(tcp_metrics, tcp_send_ex);
         if (errno == EINTR) {
-            log_verb("write on sd %d not ready - EINTR", c->sd);
+            log_verb("sendv on sd %d not ready - EINTR", c->sd);
             continue;
         } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            log_verb("write on sd %d not ready - EAGAIN", c->sd);
+            log_verb("sendv on sd %d not ready - EAGAIN", c->sd);
             return CC_EAGAIN;
         } else {
             c->err = errno;
-            log_error("write on sd %d failed: %s", c->sd, strerror(errno));
+            log_error("sendv on sd %d failed: %s", c->sd, strerror(errno));
             return CC_ERROR;
         }
     }
@@ -790,8 +769,6 @@ tcp_send(struct tcp_conn *c, void *buf, size_t nbyte)
 {
     ASSERT(buf != NULL);
     ASSERT(nbyte > 0);
-
-    log_verb("send on sd %d, total %zu bytes", c->sd, nbyte);
 
     struct iovec iov;
     iov.iov_base = buf;


### PR DESCRIPTION
Addresses TODOs about removing duplicated code.

Removes `nbyte` parameter from `tcp_sendv` and `tcp_recvv` that was largely ignored (only used for assertion and logging).

Fixes recvv incorrectly incrementing `tcp_recv` instead of `tcp_recv_byte`.

Tested on OS X and Linux, merging the test-tcp PR. Notice that both PRs have a conflict, since the arity of `tcp_sendv` and `tcp_recvv` changed. The second to be merged needs to remove the parameter from the test calls.
