### PR TITLE
make the necessary change to support musl-gcc

### DIFF
--- a/src/cc_debug.c
+++ b/src/cc_debug.c
@@ -24,7 +24,9 @@
 
 #include <ctype.h>
 #include <errno.h>
+#ifdef CC_BACKTRACE
 #include <execinfo.h>
+#endif /* CC_BACKTRACE */
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
make execinfo.h, a glibc specific header, optional so musl-gcc can be used to build ccommon. This means musl build will be missing backtrace support. We can consider using libunwind to be an alternative in the future.
