### PR TITLE
update default debug log size

### DIFF
--- a/include/cc_debug.h
+++ b/include/cc_debug.h
@@ -29,7 +29,7 @@ extern "C" {
 
 #define DEBUG_LOG_LEVEL 4       /* default log level */
 #define DEBUG_LOG_FILE  NULL    /* default log file */
-#define DEBUG_LOG_NBUF  4 * MiB /* default log buf size */
+#define DEBUG_LOG_NBUF  0       /* default log buf size */
 #define DEBUG_LOG_INTVL 100     /* flush every 100 milliseconds */
 
 /*          name             type              default           description */

--- a/src/cc_option.c
+++ b/src/cc_option.c
@@ -559,7 +559,7 @@ option_print(struct option *opt)
     option_print_val(default_s, PATH_MAX, opt->type, opt->default_val);
     option_print_val(current_s, PATH_MAX, opt->type, opt->val);
     log_stdout(OPTION_INFO_FMT, opt->name, option_type_str[opt->type],
-            default_s, current_s);
+            current_s, default_s);
 }
 
 void


### PR DESCRIPTION
since default logs to stderr, using a size 0 creates the more conventional experience of debug logging, as we do not try to buffer log messages within applications.

The benefit of not using a buffer unless specified is that `exit()` behaves better- which flushes file buffers etc, and avoids losing logs since the background flush may not have a chance to kick in.

@kevyang to your comment on a different PR, this actually is an argument for using log_stderr in all setup routines. On the other hand, we can potentially use `atexit()` to register `log_flush` upon exit. We can discuss further which method is better.

Update: after a bit more thought I think registering a callback with `atexit()` will work better, since we can flush log more reliably not just during setup, but whenever we decide to exit for whatever reason it might be.
