### PR TITLE
hide struct timeout_event and related functions

### DIFF
--- a/include/cc_debug.h
+++ b/include/cc_debug.h
@@ -30,14 +30,12 @@ extern "C" {
 #define DEBUG_LOG_LEVEL 4       /* default log level */
 #define DEBUG_LOG_FILE  NULL    /* default log file */
 #define DEBUG_LOG_NBUF  0       /* default log buf size */
-#define DEBUG_LOG_INTVL 100     /* flush every 100 milliseconds */
 
 /*          name             type              default           description */
-#define DEBUG_OPTION(ACTION)                                                                                                      \
-    ACTION( debug_log_level, OPTION_TYPE_UINT, DEBUG_LOG_LEVEL,  "debug log level"                                               )\
-    ACTION( debug_log_file,  OPTION_TYPE_STR,  DEBUG_LOG_FILE,   "debug log file"                                                )\
-    ACTION( debug_log_nbuf,  OPTION_TYPE_UINT, DEBUG_LOG_NBUF,   "debug log buf size"                                            )\
-    ACTION( debug_log_intvl, OPTION_TYPE_UINT, DEBUG_LOG_INTVL,  "debug log flush interval in ms (only applies if buf size > 0)")
+#define DEBUG_OPTION(ACTION)                                                            \
+    ACTION( debug_log_level, OPTION_TYPE_UINT, DEBUG_LOG_LEVEL,  "debug log level"     )\
+    ACTION( debug_log_file,  OPTION_TYPE_STR,  DEBUG_LOG_FILE,   "debug log file"      )\
+    ACTION( debug_log_nbuf,  OPTION_TYPE_UINT, DEBUG_LOG_NBUF,   "debug log buf size"  )
 
 typedef struct {
     DEBUG_OPTION(OPTION_DECLARE)
@@ -120,7 +118,6 @@ struct debug_logger {
  * This will be NULL as it points to a static variable declared in cc_debug.c
  */
 extern struct debug_logger *dlog;
-extern struct timeout_event *dlog_tev;
 
 /*
  * log_stderr   - log to stderr
@@ -223,7 +220,7 @@ extern struct timeout_event *dlog_tev;
 void _log(struct debug_logger *dl, const char *file, int line, int level, const char *fmt, ...);
 void _log_hexdump(struct debug_logger *dl, int level, char *data, int datalen);
 
-int signal_ttin_logrotate(void);
+void debug_log_flush(void *arg); /* compatible type: timeout_cb_fn */
 
 #ifdef __cplusplus
 }

--- a/src/cc_log.c
+++ b/src/cc_log.c
@@ -256,14 +256,14 @@ _rbuf_flush(struct rbuf *buf, int fd)
 
         if (ret == capacity) {
             /* more can be written, read from beginning of buf */
-            ssize_t remaining_bytes;
+            ssize_t ret2;
 
             capacity = wpos;
-            remaining_bytes = write(fd, buf->data, capacity);
+            ret2 = write(fd, buf->data, capacity);
 
-            if (remaining_bytes >= 0) {
-                rpos = remaining_bytes;
-                ret += remaining_bytes;
+            if (ret2 >= 0) {
+                rpos = ret2;
+                ret += ret2;
             }
         }
     } else {


### PR DESCRIPTION
This round of refactor aims at timing wheel, mostly, to make life-cycle management of timed actions (`timeout_event`) less prone to misuse.

Please see the comment in `cc_wheel.h` for some explanation.

One fundamental difficulty of the situation is to allow a `timeout_event` to be removed cheaply before it expires (e.g. request timeout should be canceled if a response is returned in time, which is the common case), but not leaving orphaned resources behind when the timeouts do trigger. At which point, as explained in the comment, it is hard to assume what the callback will do. And the callback function probably prefers not to manage this.

The current refactoring still leaves one vulnerability- dangling pointers when events are non-recurring. The pointer we returned for quick event removal becomes a dangling pointer when the event gets triggered **and** removed (not a problem if it's reinserted). To avoid this problem, the owner of that pointer should only try to remove an event that has not been triggered yet.

How easily it is for the pointer owner to know for sure that the timeout has not been triggered? This is a somewhat tricky question. The use cases we currently want to support in the non-recurring scenario, such as request timeouts, can be setup to guarantee that. Each request is likely to own one or more timeout event pointers, and the callback function is likely to pass back the request (as a pointer or part of a bigger struct) as argument. So in the callback, instead of trying to free up the event (required with pre-refactoring timing wheel), it should set the corresponding pointer to `NULL` when using the post-refactoring timing wheel library.
