### PR TITLE
fix shadow declaration in tcp unit test

### DIFF
--- a/test/tcp/check_tcp.c
+++ b/test/tcp/check_tcp.c
@@ -19,11 +19,11 @@ static struct tcp_conn *client;
  * utilities
  */
 static int
-get_addr(struct addrinfo **ai)
+get_addr(struct addrinfo **ai_ptr)
 {
     struct addrinfo hints = { .ai_flags = AI_PASSIVE, .ai_family = AF_UNSPEC,
                               .ai_socktype = SOCK_STREAM };
-    return getaddrinfo(HOST, PORT, &hints, ai);
+    return getaddrinfo(HOST, PORT, &hints, ai_ptr);
 }
 
 static void


### PR DESCRIPTION
missed this in the last PR, going to just merge it since it's a simple rename of a local variable
