### PR TITLE
small updates

### DIFF
--- a/src/cc_debug.c
+++ b/src/cc_debug.c
@@ -89,6 +89,7 @@ debug_assert(const char *cond, const char *file, int line, int panic)
 static void
 _stacktrace(int signo)
 {
+    log_stderr("received signal %d", signo);
     debug_stacktrace(2); /* skipping functions inside signal module */
     raise(signo);
 }


### PR DESCRIPTION
- reduce log noise introduced by recurring timeout events in timing wheel
- log signal value when SIGSEGV is thrown.
