### PR TITLE
fixed test linkage for ubuntu

### DIFF
--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -5,7 +5,16 @@ rm -rf lcov _build _bin && mkdir _build && pushd _build && cmake -DCOVERAGE=on .
 mkdir lcov
 lcov --directory . --capture --output-file lcov/app.info
 genhtml lcov/app.info -o lcov/html
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    open lcov/html/index.html
+
+COVERAGE_FILE="lcov/html/index.html"
+if which xdg-open; then
+    OPEN=xdg-open
+elif [[ $OSTYPE == "darwin"* ]]; then
+    OPEN=open
+else
+    >&2 echo "Don't know how to automate open, coverage file is at: $COVERAGE_FILE"
+fi
+if [[ ! -z "$OPEN" ]]; then
+    $OPEN $COVERAGE_FILE
 fi
 set +e

--- a/test/array/CMakeLists.txt
+++ b/test/array/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/array/CMakeLists.txt
+++ b/test/array/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/bstring/CMakeLists.txt
+++ b/test/bstring/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/bstring/CMakeLists.txt
+++ b/test/bstring/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/channel/pipe/CMakeLists.txt
+++ b/test/channel/pipe/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} m)
 target_link_libraries(${test_name} ${CMAKE_THREAD_LIBS_INIT})
 
 add_dependencies(check ${test_name})

--- a/test/channel/pipe/CMakeLists.txt
+++ b/test/channel/pipe/CMakeLists.txt
@@ -4,8 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} m)
-target_link_libraries(${test_name} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/channel/tcp/CMakeLists.txt
+++ b/test/channel/tcp/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} m)
 target_link_libraries(${test_name} ${CMAKE_THREAD_LIBS_INIT})
 
 add_dependencies(check ${test_name})

--- a/test/channel/tcp/CMakeLists.txt
+++ b/test/channel/tcp/CMakeLists.txt
@@ -4,8 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} m)
-target_link_libraries(${test_name} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/event/CMakeLists.txt
+++ b/test/event/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/event/CMakeLists.txt
+++ b/test/event/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/metric/CMakeLists.txt
+++ b/test/metric/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/option/CMakeLists.txt
+++ b/test/option/CMakeLists.txt
@@ -4,8 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES})
-target_link_libraries(${test_name} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/option/CMakeLists.txt
+++ b/test/option/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} m)
 
 add_dependencies(check ${test_name})

--- a/test/pool/CMakeLists.txt
+++ b/test/pool/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/pool/CMakeLists.txt
+++ b/test/pool/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/rbuf/CMakeLists.txt
+++ b/test/rbuf/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/rbuf/CMakeLists.txt
+++ b/test/rbuf/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/ring_array/CMakeLists.txt
+++ b/test/ring_array/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/ring_array/CMakeLists.txt
+++ b/test/ring_array/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/time/timer/CMakeLists.txt
+++ b/test/time/timer/CMakeLists.txt
@@ -4,8 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES})
-target_link_libraries(${test_name} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/time/timer/CMakeLists.txt
+++ b/test/time/timer/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} m)
 
 add_dependencies(check ${test_name})

--- a/test/time/wheel/CMakeLists.txt
+++ b/test/time/wheel/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
+target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/time/wheel/CMakeLists.txt
+++ b/test/time/wheel/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_name check_${suite})
 set(source check_${suite}.c)
 
 add_executable(${test_name} ${source})
-target_link_libraries(${test_name} ccommon-static ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m)
 
 add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})


### PR DESCRIPTION
* fixed test linkage for ubuntu, tested on 14.04.
  * while adding libs, added by preferring to add to the front, so dependencies are flushed out, ie m needing to be at the rear.
  * an alternative approach would be to have a common set of libs for all tests, but preferred to add explicit dependencies per test suite.
* added support for test-coverage.sh to use xdg-open rather than open when present, ie on ubuntu.