### PR TITLE
remove install instructions; get rid of cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ configure_file(
 # so we are using list as input until we move to new version
 # TODO add build types
 add_definitions(-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64)
+set(CMAKE_MACOSX_RPATH 1)
 set(CFLAGS_LIST
     "-std=c11 "
     "-ggdb3 -O2 "

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,10 +35,3 @@ set_target_properties (${PROJECT_NAME}-shared
     OUTPUT_NAME ${PROJECT_NAME}
     VERSION ${${PROJECT_NAME}_VERSION}
     SOVERSION 0)
-
-# install instructions
-install(TARGETS ${PROJECT_NAME}-static DESTINATION lib)
-install(TARGETS ${PROJECT_NAME}-shared DESTINATION lib)
-install(DIRECTORY include/
-    DESTINATION include/${PROJECT_NAME}-${${PROJECT_NAME}_RELEASE_VERSION}
-    FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
The current install instruction doesn't quite work (includes not installed).

It is also problematic when used as part of pelikan- we want `make install` to just install the server binaries, but currently it will try to install the library as well.

So we are removing the install instructions for now and investigate later.

Also setting a variable for RPATH on OSX to rid warning.