### PR TITLE
Fixed cmake install instructions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,3 +35,10 @@ set_target_properties (${PROJECT_NAME}-shared
     OUTPUT_NAME ${PROJECT_NAME}
     VERSION ${${PROJECT_NAME}_VERSION}
     SOVERSION 0)
+
+# install instructions
+install(TARGETS ${PROJECT_NAME}-static DESTINATION lib)
+install(TARGETS ${PROJECT_NAME}-shared DESTINATION lib)
+install(DIRECTORY ../include/
+    DESTINATION include/${PROJECT_NAME}-${${PROJECT_NAME}_RELEASE_VERSION}
+    FILES_MATCHING PATTERN "*")


### PR DESCRIPTION
fix for Issue #125
- fixed and re-added cmake install instructions, w/ following notes:
  - include directory made proper relative
  - opened pattern match b/c include directory should only contain files meant for inclusion.

Manually tested by verifying the contents of /usr/local/include/ccommon-1.0/ match those of the project, including include subdirectories.
