### PR TITLE
adding a new API to duration timer

### DIFF
--- a/include/time/cc_timer.h
+++ b/include/time/cc_timer.h
@@ -90,7 +90,7 @@ struct timeout {
 /* update duration */
 void duration_reset(struct duration *d);
 /* get a reading of duration and copy it without stopping the original timer */
-void duration_snapshot(struct duration *s, struct duration *d);
+void duration_snapshot(struct duration *s, const struct duration *d);
 void duration_start(struct duration *d);
 void duration_stop(struct duration *d);
 /* read duration */

--- a/include/time/cc_timer.h
+++ b/include/time/cc_timer.h
@@ -89,6 +89,8 @@ struct timeout {
 
 /* update duration */
 void duration_reset(struct duration *d);
+/* get a reading of duration and copy it without stopping the original timer */
+void duration_snapshot(struct duration *s, struct duration *d);
 void duration_start(struct duration *d);
 void duration_stop(struct duration *d);
 /* read duration */

--- a/src/time/cc_timer_darwin.c
+++ b/src/time/cc_timer_darwin.c
@@ -53,6 +53,17 @@ duration_reset(struct duration *d)
 }
 
 void
+duration_snapshot(struct duration *s, struct duration *d)
+{
+    ASSERT(s != 0 && d != NULL);
+
+    s->started = true;
+    s->start = d->start;
+    s->stopped = true;
+    s->stop = mach_absolute_time();
+}
+
+void
 duration_start(struct duration *d)
 {
     ASSERT(d != NULL);

--- a/src/time/cc_timer_darwin.c
+++ b/src/time/cc_timer_darwin.c
@@ -53,7 +53,7 @@ duration_reset(struct duration *d)
 }
 
 void
-duration_snapshot(struct duration *s, struct duration *d)
+duration_snapshot(struct duration *s, const struct duration *d)
 {
     ASSERT(s != 0 && d != NULL);
 

--- a/src/time/cc_timer_linux.c
+++ b/src/time/cc_timer_linux.c
@@ -81,7 +81,7 @@ duration_start(struct duration *d)
 }
 
 void
-duration_snapshot(struct duration *s, struct duration *d)
+duration_snapshot(struct duration *s, const struct duration *d)
 {
     ASSERT(s != 0 && d != NULL);
 

--- a/src/time/cc_timer_linux.c
+++ b/src/time/cc_timer_linux.c
@@ -81,6 +81,17 @@ duration_start(struct duration *d)
 }
 
 void
+duration_snapshot(struct duration *s, struct duration *d)
+{
+    ASSERT(s != 0 && d != NULL);
+
+    s->started = true;
+    s->start = d->start;
+    s->stopped = true;
+    _gettime(&s->stop);
+}
+
+void
 duration_stop(struct duration *d)
 {
     ASSERT(d != NULL);

--- a/test/time/timer/check_timer.c
+++ b/test/time/timer/check_timer.c
@@ -31,18 +31,25 @@ START_TEST(test_duration)
 {
 #define DURATION_NS 100000
 
-    struct duration d;
-    double d_ns, d_us, d_ms, d_sec;
+    struct duration d, s;
+    double d_ns, d_us, d_ms, d_sec, s_ns;
     struct timespec ts = (struct timespec){0, DURATION_NS};
 
     duration_reset(&d);
     duration_start(&d);
     nanosleep(&ts, NULL);
+    duration_snapshot(&s, &d);
+
+    /* snapshot is as expected */
+    s_ns = duration_ns(&s);
+    ck_assert_uint_ge((unsigned int)s_ns, DURATION_NS);
+
+    nanosleep(&ts, NULL);
     duration_stop(&d);
 
-    /* duration is as expected */
+    /* final duration is as expected */
     d_ns = duration_ns(&d);
-    ck_assert_uint_ge((unsigned int)d_ns, DURATION_NS);
+    ck_assert_uint_ge((unsigned int)d_ns, 2 * DURATION_NS);
 
     /* readings of different units are consistent */
     d_us = duration_us(&d);


### PR DESCRIPTION
the `duration_snapshot` API allows caller to get a current reading of a started duration `d` and store it into `s`, while leaving `d` still running.