### PR TITLE
a single job in the travis-ci matrix for building with rust enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,17 @@ matrix:
             - gcc-5
             - libsubunit-dev
 
+    # gcc 5 on linux
+    - env:
+        - C_COMPILER=gcc-5
+        - RUST_ENABLED=1
+      addons:
+        apt:
+          <<: *apt
+          packages:
+            - gcc-5
+            - libsubunit-dev
+
     # clang 3.6 on linux
     - env:
         - C_COMPILER=clang-3.6

--- a/ci/before-install.sh
+++ b/ci/before-install.sh
@@ -26,4 +26,6 @@ fi
 
 export CC="$C_COMPILER"
 
-# curl https://sh.rustup.rs -sSf | sh -s -- -y
+if [[ -n "${RUST_ENABLED:-}" ]]; then
+  curl https://sh.rustup.rs -sSf | sh -s -- -y
+fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,7 +7,18 @@ die() { echo "fatal: $*" >&2; exit 1; }
 
 export PATH=$HOME/.cargo/bin:$PATH
 
-mkdir -p _build && ( cd _build && cmake -D BUILD_AND_INSTALL_CHECK=yes .. && make -j && make check )
+cmake_cmd=(
+  cmake
+  -DBUILD_AND_INSTALL_CHECK=yes
+)
+
+if [[ -n "${RUST_ENABLED:-}" ]]; then
+  cmake_cmd+=( -DHAVE_RUST=yes -DRUST_VERBOSE_BUILD=yes )
+fi
+
+export RUST_BACKTRACE=full
+
+mkdir -p _build && ( cd _build && "${cmake_cmd[@]}" .. && make -j && make check )
 RESULT=$?
 
 egrep -r ":F:|:E:" . |grep -v 'Binary file' || true


### PR DESCRIPTION
Add one job in the travis-ci test matrix to test that the rust code builds, links, and tests correctly.

HAVE_RUST is sill defaulted to "off".