### PR TITLE
forgot to remove unused include

### DIFF
--- a/test/ring_array/check_ring_array.c
+++ b/test/ring_array/check_ring_array.c
@@ -6,8 +6,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <unistd.h>
-
 #define SUITE_NAME "ring_array"
 #define DEBUG_LOG  SUITE_NAME ".log"
 


### PR DESCRIPTION
Problem

Forgot to remove an include that is no longer used in check_ring_array.

Solution

Removed the unused header.
