### PR TITLE
create a .cargo/config so intellij uses the same target dir as cmake

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,1 +1,2 @@
 Cargo.lock
+.cargo/

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -1,5 +1,12 @@
 file(WRITE CMAKE_BINARY_DIR "${CMAKE_BINARY_DIR}\n")
 
+execute_process(
+    COMMAND /usr/bin/env "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}" "/bin/bash" "${CMAKE_CURRENT_LIST_DIR}/scripts/setup.sh"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+    RESULT_VARIABLE CARGO_RESULT
+    OUTPUT_VARIABLE CARGO_CONFIG_OUT
+    ERROR_VARIABLE CARGO_CONFIG_OUT)
+
 if(HAVE_RUST)
     add_subdirectory(ccommon_rs)
 endif()

--- a/rust/scripts/setup.sh
+++ b/rust/scripts/setup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# utility script run by cmake for writing a .cargo/config that points
+# to the common 'target' directory under the CMAKE_BINARY_DIR. This
+# allows automated tools (such as the intellij rust plugin or vcode
+# rust integration) to share output and avoid recompiling between
+# the command line and the IDE.
+#
+# it is assumed that this script is run with the CWD being the
+# place where the .cargo dir should be created.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+die() { echo "fatal: $*" >&2; exit 1; }
+
+if [[ -z "${CMAKE_BINARY_DIR:-}" ]]; then
+  die "CMAKE_BINARY_DIR must be set!"
+fi
+
+mkdir -p .cargo
+
+cleanup() {
+  [[ -n "${TEMPFILE:-}" ]] && rm -rf "$TEMPFILE"
+}
+trap cleanup EXIT
+
+TEMPFILE="$(mktemp '.cargo/config.XXXXXXXX')" || die "could not create tempfile"
+
+cat > "$TEMPFILE" <<EOS
+[build]
+target-dir = "${CMAKE_BINARY_DIR}/target"
+EOS
+
+mv "$TEMPFILE" .cargo/config


### PR DESCRIPTION
Problem

IntelliJ (and ostensibly other IDEs) build the rust portion of ccommon as a "cargo project" in `rust/`, which means it will create `rust/target` and output there. When cmake runs in the tld, it will re-compile all the rust targets in `_build/`. One can use an env var of `CARGO_TARGET_DIR` to control this, but that doesn't help because there's no easy way to set that variable automatically inside IntelliJ (and potentially in other IDEs). 

Solution

Cargo will look at `.cargo/config` in each directory in a project for configuration. We run a small script from cmake that writes this file out and sets the target dir to the same one that cmake uses.

Result

We no longer compile the same thing twice to two different locations.