### PR TITLE
improve cc_bstring string literal and cstring names

### DIFF
--- a/include/cc_bstring.h
+++ b/include/cc_bstring.h
@@ -38,15 +38,14 @@ struct bstring {
 #define str2bstr(_str)  (struct bstring){ sizeof(_str) - 1, (_str) }
 #define null_bstring    (struct bstring){ 0, NULL }
 
-#define bstring_set_text(_str, _text) do {       \
-    (_str)->len = (uint32_t)(sizeof(_text) - 1); \
-    (_str)->data = (_text);                      \
+#define bstring_set_literal(_str, _literal) do {    \
+    (_str)->len = (uint32_t)(sizeof(_literal) - 1); \
+    (_str)->data = (_literal);                      \
 } while (0);
 
-/* TODO(yao): rename this */
-#define bstring_set_raw(_str, _raw) do {         \
-    (_str)->len = (uint32_t)(cc_strlen(_raw));   \
-    (_str)->data = (char *)(_raw);               \
+#define bstring_set_cstr(_str, _cstr) do {       \
+    (_str)->len = (uint32_t)(cc_strlen(_cstr));  \
+    (_str)->data = (char *)(_cstr);              \
 } while (0);
 
 void bstring_init(struct bstring *str);

--- a/rust/ccommon_rs/src/log/mod.rs
+++ b/rust/ccommon_rs/src/log/mod.rs
@@ -46,8 +46,8 @@
 //! log_setup()
 //! {
 //! 	log_config.buf_size = 1024;
-//! 	bstring_set_raw(&log_config.prefix, "templog");
-//! 	bstring_set_raw(&log_config.path, PATH);
+//! 	bstring_set_cstr(&log_config.prefix, "templog");
+//! 	bstring_set_cstr(&log_config.path, PATH);
 //! 	log_config.level = LOG_LEVEL_TRACE;
 //!
 //! 	log_handle = log_create_handle_rs(&log_config);

--- a/src/cc_bstring.c
+++ b/src/cc_bstring.c
@@ -33,9 +33,9 @@
  * raw sequence of character bytes - bstring_copy(). Such String's must be
  * freed using bstring_deinit()
  *
- * We can also create String as reference to raw string - bstring_set_raw()
- * or to string literal - bstring_set_text() or bstring(). Such bstrings don't
- * have to be freed.
+ * We can also create String as reference to C string - bstring_set_cstr()
+ * or to string literal - bstring_set_literal() or bstring(). Such bstrings
+ * don't have to be freed.
  */
 
 void

--- a/test/log/check_log.c
+++ b/test/log/check_log.c
@@ -260,8 +260,8 @@ START_TEST(test_most_basic_rust_logging_setup_teardown)
 
     struct log_config_rs cfg;
     cfg.buf_size = 1024;
-    bstring_set_raw(&cfg.prefix, "templog");
-    bstring_set_raw(&cfg.path, path);
+    bstring_set_cstr(&cfg.prefix, "templog");
+    bstring_set_cstr(&cfg.path, path);
     cfg.level = LOG_LEVEL_TRACE;
 
     struct log_handle_rs *handle = log_create_handle_rs(&cfg);


### PR DESCRIPTION
Problem

The macro names in cc_bstring to build bstring from string literals/cstrings are not as clear as we would like them to be.

Solution

I have updated the names of these macros to reflect the names we had agreed on.
