### PR TITLE
epoll_create* ignores size hint in newer kernels, switch to new API

### DIFF
--- a/include/cc_event.h
+++ b/include/cc_event.h
@@ -26,8 +26,6 @@ extern "C" {
 
 #include <inttypes.h>
 
-#define EVENT_SIZE  1024
-
 #define EVENT_READ  0x0000ff
 #define EVENT_WRITE 0x00ff00
 #define EVENT_ERR   0xff0000
@@ -51,7 +49,7 @@ void event_setup(event_metrics_st *metrics);
 void event_teardown(void);
 
 /* event base */
-struct event_base *event_base_create(int size, event_cb_fn cb);
+struct event_base *event_base_create(int nevent, event_cb_fn cb);
 void event_base_destroy(struct event_base **evb);
 
 /* event control */

--- a/src/event/cc_epoll.c
+++ b/src/event/cc_epoll.c
@@ -57,7 +57,7 @@ event_base_create(int nevent, event_cb_fn cb)
 
     ASSERT(nevent > 0);
 
-    ep = epoll_create(nevent);
+    ep = epoll_create1(0);
     if (ep < 0) {
         log_error("epoll create size %d failed: %s", nevent, strerror(errno));
         return NULL;

--- a/src/event/cc_epoll.c
+++ b/src/event/cc_epoll.c
@@ -59,7 +59,7 @@ event_base_create(int nevent, event_cb_fn cb)
 
     ep = epoll_create1(0);
     if (ep < 0) {
-        log_error("epoll create size %d failed: %s", nevent, strerror(errno));
+        log_error("epoll create1 failed: %s", strerror(errno));
         return NULL;
     }
 


### PR DESCRIPTION
Problem

epoll_create() no longer take size hint

Solution

use new API and drop the hint.

Result

No behavioral change.
