### PR TITLE
Revert "remove endian-specific logic from str*cmp"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ endif()
 # config.h.in has to include entries set/tested here for them to have effect
 
 # version info
-set(${PROJECT_NAME}_VERSION_MAJOR 2)
-set(${PROJECT_NAME}_VERSION_MINOR 0)
+set(${PROJECT_NAME}_VERSION_MAJOR 1)
+set(${PROJECT_NAME}_VERSION_MINOR 2)
 set(${PROJECT_NAME}_VERSION_PATCH 0)
 set(${PROJECT_NAME}_VERSION
    ${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}
@@ -97,6 +97,9 @@ check_symbol_exists(sys_signame signal.h HAVE_SIGNAME)
 include(CheckFunctionExists)
 check_function_exists(backtrace HAVE_BACKTRACE)
 check_function_exists(accept4 HAVE_ACCEPT4)
+
+include(TestBigEndian)
+test_big_endian(HAVE_BIG_ENDIAN)
 
 # how to use config.h.in to generate config.h
 # this has to be set _after_ the above checks
@@ -187,5 +190,6 @@ message(STATUS "CFLAGS: " ${CMAKE_C_FLAGS})
 message(STATUS "HAVE_SIGNAME: " ${HAVE_SIGNAME})
 
 message(STATUS "HAVE_BACKTRACE: " ${HAVE_BACKTRACE})
+message(STATUS "HAVE_BIG_ENDIAN: " ${HAVE_BIG_ENDIAN})
 
 message(STATUS "CHECK_WORKING: " ${CHECK_WORKING})

--- a/config.h.in
+++ b/config.h.in
@@ -14,6 +14,8 @@
 
 #cmakedefine HAVE_ACCEPT4
 
+#cmakedefine HAVE_BIG_ENDIAN
+
 #cmakedefine HAVE_LOGGING
 
 #cmakedefine HAVE_STATS

--- a/include/cc_bstring.h
+++ b/include/cc_bstring.h
@@ -58,6 +58,7 @@ int bstring_compare(const struct bstring *s1, const struct bstring *s2);
 struct bstring *bstring_alloc(uint32_t size);
 void bstring_free(struct bstring **bstring);
 
+/* TODO(yao): is this endian thing really useful? */
 /* efficient implementation of string comparion of short strings */
 #define str2cmp(m, c0, c1)                                                     \
     (m[0] == c0 && m[1] == c1)
@@ -65,48 +66,8 @@ void bstring_free(struct bstring **bstring);
 #define str3cmp(m, c0, c1, c2)                                                 \
     (m[0] == c0 && m[1] == c1 && m[2] == c2)
 
-#define str4cmp(m, c0, c1, c2, c3)                                             \
-    ((m[0] << 24 | m[1] << 16 | m[2] << 8 | m[3]) ==                           \
-        ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3))
+#ifdef CC_LITTLE_ENDIAN
 
-#define str5cmp(m, c0, c1, c2, c3, c4)                                         \
-    (str4cmp(m, c0, c1, c2, c3) && (m[4] == c4))
-
-#define str6cmp(m, c0, c1, c2, c3, c4, c5)                                     \
-    (str5cmp(m, c0, c1, c2, c3, c4) && m[5] == c5)
-
-#define str7cmp(m, c0, c1, c2, c3, c4, c5, c6)                                 \
-    (str6cmp(m, c0, c1, c2, c3, c4, c5) && m[6] == c6)
-
-#define str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                             \
-    (str4cmp(m, c0, c1, c2, c3) &&                                             \
-        (m[4] << 24 | m[5] << 16 | m[6] << 8 | m[7]) ==                        \
-        ((c4 << 24) | (c5 << 16) | (c6 << 8) | c7))
-
-#define str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                         \
-    (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) && m[8] == c8)
-
-#define str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                    \
-    (str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8) && m[9] == c9)
-
-#define str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)               \
-    (str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9) && m[10] == c10)
-
-#define str12cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)          \
-    (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                             \
-        (m[8] << 24 | m[9] << 16 | m[10] << 8 | m[11]) ==                      \
-        ((c8 << 24) | (c9 << 16) | (c10 << 8) | c11))
-
-/* below is a more efficient implementation for little-endian only, it takes
- * about 50% the cycles compared to the generic implementation above in the
- * extreme cases (e.g. string length being multiples of 4), however, our
- * profiling showed that string comparison does not contribute meaningfully to
- * overall processing cost, both events and hashes are far more notable, and
- * therefore we can choose the generic implementation until profiling results
- * indicate otherwise.
- */
-
-/*
 #define str4cmp(m, c0, c1, c2, c3)                                             \
     (*(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0))
 
@@ -137,7 +98,38 @@ void bstring_free(struct bstring **bstring);
 #define str12cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)          \
     (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                             \
         (((uint32_t *) m)[2] == ((c11 << 24) | (c10 << 16) | (c9 << 8) | c8)))
-*/
+
+#else // BIG ENDIAN
+
+#define str4cmp(m, c0, c1, c2, c3)                                             \
+    (str3cmp(m, c0, c1, c2) && (m3 == c3))
+
+#define str5cmp(m, c0, c1, c2, c3, c4)                                         \
+    (str4cmp(m, c0, c1, c2, c3) && (m[4] == c4))
+
+#define str6cmp(m, c0, c1, c2, c3, c4, c5)                                     \
+    (str5cmp(m, c0, c1, c2, c3, c4) && m[5] == c5)
+
+#define str7cmp(m, c0, c1, c2, c3, c4, c5, c6)                                 \
+    (str6cmp(m, c0, c1, c2, c3, c4, c5) && m[6] == c6)
+
+#define str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                             \
+    (str7cmp(m, c0, c1, c2, c3, c4, c5, c6) && m[7] == c7)
+
+#define str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                         \
+    (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) && m[8] == c8)
+
+#define str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                    \
+    (str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8) && m[9] == c9)
+
+#define str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)               \
+    (str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9) && m[10] == c10)
+
+#define str12cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)          \
+    (str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) && m[11] == c11)
+
+#endif // CC_LITTLE_ENDIAN
+
 
 /*
  * Wrapper around common routines for manipulating C character strings

--- a/include/cc_define.h
+++ b/include/cc_define.h
@@ -27,6 +27,13 @@ extern "C" {
 # define CC_HAVE_SIGNAME 1
 #endif
 
+
+#ifdef HAVE_BIG_ENDIAN
+# define CC_BIG_ENDIAN 1
+#else
+# define CC_LITTLE_ENDIAN 1
+#endif
+
 #ifdef HAVE_STATS
 # define CC_STATS 1
 #endif

--- a/include/hash/cc_lookup3.h
+++ b/include/hash/cc_lookup3.h
@@ -1,0 +1,33 @@
+/*
+ * ccommon - a cache common library.
+ * Copyright (C) 2013 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cc_define.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+uint32_t hash_lookup3(const void *key, size_t length, const uint32_t initval);
+
+#ifdef __cplusplus
+}
+#endif

--- a/rust/cc_binding/build.rs
+++ b/rust/cc_binding/build.rs
@@ -48,7 +48,7 @@ fn get_cmake_cache_value(binary_dir: &Path, key: &str) -> Result<Option<String>>
 }
 
 fn main() {
-    println!("cargo:rustc-link-lib=static=ccommon-2.0.0");
+    println!("cargo:rustc-link-lib=static=ccommon-1.2.0");
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-lib=framework=Security");
     }

--- a/src/hash/CMakeLists.txt
+++ b/src/hash/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCE
     ${SOURCE}
+    hash/cc_lookup3.c
     hash/cc_murmur3.c
     PARENT_SCOPE)

--- a/src/hash/cc_lookup3.c
+++ b/src/hash/cc_lookup3.c
@@ -1,0 +1,446 @@
+/*
+ * ccommon - a cache common library.
+ * Copyright (C) 2013 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Hash table
+ *
+ * The hash function used here is by Bob Jenkins, 1996:
+ *   <http://burtleburtle.net/bob/hash/doobs.html>
+ *   "By Bob Jenkins, 1996.  bob_jenkins@burtleburtle.net.
+ *   You may use this code any way you wish, private, educational,
+ *   or commercial.  It's free."
+ *
+ */
+
+/*
+ * Since the hash function does bit manipulation, it needs to know
+ * whether it's big or little-endian. HAVE_LITTLE_ENDIAN and HAVE_BIG_ENDIAN
+ * are set in the configure script.
+ */
+#include <hash/cc_lookup3.h>
+
+#if defined CC_BIG_ENDIAN && CC_BIG_ENDIAN == 1
+# define HASH_LITTLE_ENDIAN 0
+# define HASH_BIG_ENDIAN    1
+#elif defined CC_LITTLE_ENDIAN && CC_LITTLE_ENDIAN == 1
+# define HASH_LITTLE_ENDIAN 1
+# define HASH_BIG_ENDIAN    0
+#else
+# define HASH_LITTLE_ENDIAN 0
+# define HASH_BIG_ENDIAN    0
+#endif
+
+#define rot(x,k) (((x)<<(k)) ^ ((x)>>(32-(k))))
+
+/*
+-------------------------------------------------------------------------------
+mix -- mix 3 32-bit values reversibly.
+
+This is reversible, so any information in (a,b,c) before mix() is
+still in (a,b,c) after mix().
+
+If four pairs of (a,b,c) inputs are run through mix(), or through
+mix() in reverse, there are at least 32 bits of the output that
+are sometimes the same for one pair and different for another pair.
+This was tested for:
+* pairs that differed by one bit, by two bits, in any combination
+  of top bits of (a,b,c), or in any combination of bottom bits of
+  (a,b,c).
+* "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+  the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+  is commonly produced by subtraction) look like a single 1-bit
+  difference.
+* the base values were pseudorandom, all zero but one bit set, or
+  all zero plus a counter that starts at zero.
+
+Some k values for my "a-=c; a^=rot(c,k); c+=b;" arrangement that
+satisfy this are
+    4  6  8 16 19  4
+    9 15  3 18 27 15
+   14  9  3  7 17  3
+Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing
+for "differ" defined as + with a one-bit base and a two-bit delta.  I
+used http://burtleburtle.net/bob/hash/avalanche.html to choose
+the operations, constants, and arrangements of the variables.
+
+This does not achieve avalanche.  There are input bits of (a,b,c)
+that fail to affect some output bits of (a,b,c), especially of a.  The
+most thoroughly mixed value is c, but it doesn't really even achieve
+avalanche in c.
+
+This allows some parallelism.  Read-after-writes are good at doubling
+the number of bits affected, so the goal of mixing pulls in the opposite
+direction as the goal of parallelism.  I did what I could.  Rotates
+seem to cost as much as shifts on every machine I could lay my hands
+on, and rotates are much kinder to the top and bottom bits, so I used
+rotates.
+-------------------------------------------------------------------------------
+*/
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+/*
+-------------------------------------------------------------------------------
+final -- final mixing of 3 32-bit values (a,b,c) into c
+
+Pairs of (a,b,c) values differing in only a few bits will usually
+produce values of c that look totally different.  This was tested for
+* pairs that differed by one bit, by two bits, in any combination
+  of top bits of (a,b,c), or in any combination of bottom bits of
+  (a,b,c).
+* "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+  the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+  is commonly produced by subtraction) look like a single 1-bit
+  difference.
+* the base values were pseudorandom, all zero but one bit set, or
+  all zero plus a counter that starts at zero.
+
+These constants passed:
+ 14 11 25 16 4 14 24
+ 12 14 25 16 4 14 24
+and these came close:
+  4  8 15 26 3 22 24
+ 10  8 15 26 3 22 24
+ 11  8 15 26 3 22 24
+-------------------------------------------------------------------------------
+*/
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+#if HASH_LITTLE_ENDIAN == 1
+uint32_t hash_lookup3(
+  const void *key,       /* the key to hash */
+  size_t      length,    /* length of the key */
+  const uint32_t    initval)   /* initval */
+{
+  uint32_t a,b,c;                                          /* internal state */
+  union { const void *ptr; size_t i; } u;     /* needed for Mac Powerbook G4 */
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef + ((uint32_t)length) + initval;
+
+  u.ptr = key;
+  if (HASH_LITTLE_ENDIAN && ((u.i & 0x3) == 0)) {
+    const uint32_t *k = (const uint32_t *)key;         /* read 32-bit chunks */
+#ifdef VALGRIND
+    const uint8_t  *k8;
+#endif /* ifdef VALGRIND */
+
+    /*------ all but last block: aligned reads and affect 32 bits of (a,b,c) */
+    while (length > 12)
+    {
+      a += k[0];
+      b += k[1];
+      c += k[2];
+      mix(a,b,c);
+      length -= 12;
+      k += 3;
+    }
+
+    /*----------------------------- handle the last (probably partial) block */
+    /*
+     * "k[2]&0xffffff" actually reads beyond the end of the string, but
+     * then masks off the part it's not allowed to read.  Because the
+     * string is aligned, the masked-off tail is in the same word as the
+     * rest of the string.  Every machine with memory protection I've seen
+     * does it on word boundaries, so is OK with this.  But VALGRIND will
+     * still catch it and complain.  The masking trick does make the hash
+     * noticably faster for short strings (like English words).
+     */
+#ifndef VALGRIND
+
+    switch(length)
+    {
+    case 12: c+=k[2]; b+=k[1]; a+=k[0]; break;
+    case 11: c+=k[2]&0xffffff; b+=k[1]; a+=k[0]; break;
+    case 10: c+=k[2]&0xffff; b+=k[1]; a+=k[0]; break;
+    case 9 : c+=k[2]&0xff; b+=k[1]; a+=k[0]; break;
+    case 8 : b+=k[1]; a+=k[0]; break;
+    case 7 : b+=k[1]&0xffffff; a+=k[0]; break;
+    case 6 : b+=k[1]&0xffff; a+=k[0]; break;
+    case 5 : b+=k[1]&0xff; a+=k[0]; break;
+    case 4 : a+=k[0]; break;
+    case 3 : a+=k[0]&0xffffff; break;
+    case 2 : a+=k[0]&0xffff; break;
+    case 1 : a+=k[0]&0xff; break;
+    case 0 : return c;  /* zero length strings require no mixing */
+    }
+
+#else /* make valgrind happy */
+
+    k8 = (const uint8_t *)k;
+    switch(length)
+    {
+    case 12: c+=k[2]; b+=k[1]; a+=k[0]; break;
+    case 11: c+=((uint32_t)k8[10])<<16;  /* fall through */
+    case 10: c+=((uint32_t)k8[9])<<8;    /* fall through */
+    case 9 : c+=k8[8];                   /* fall through */
+    case 8 : b+=k[1]; a+=k[0]; break;
+    case 7 : b+=((uint32_t)k8[6])<<16;   /* fall through */
+    case 6 : b+=((uint32_t)k8[5])<<8;    /* fall through */
+    case 5 : b+=k8[4];                   /* fall through */
+    case 4 : a+=k[0]; break;
+    case 3 : a+=((uint32_t)k8[2])<<16;   /* fall through */
+    case 2 : a+=((uint32_t)k8[1])<<8;    /* fall through */
+    case 1 : a+=k8[0]; break;
+    case 0 : return c;  /* zero length strings require no mixing */
+    }
+
+#endif /* !valgrind */
+
+  } else if (HASH_LITTLE_ENDIAN && ((u.i & 0x1) == 0)) {
+    const uint16_t *k = (const uint16_t *)key;         /* read 16-bit chunks */
+    const uint8_t  *k8;
+
+    /*--------------- all but last block: aligned reads and different mixing */
+    while (length > 12)
+    {
+      a += k[0] + (((uint32_t)k[1])<<16);
+      b += k[2] + (((uint32_t)k[3])<<16);
+      c += k[4] + (((uint32_t)k[5])<<16);
+      mix(a,b,c);
+      length -= 12;
+      k += 6;
+    }
+
+    /*----------------------------- handle the last (probably partial) block */
+    k8 = (const uint8_t *)k;
+    switch(length)
+    {
+    case 12: c+=k[4]+(((uint32_t)k[5])<<16);
+             b+=k[2]+(((uint32_t)k[3])<<16);
+             a+=k[0]+(((uint32_t)k[1])<<16);
+             break;
+    case 11: c+=((uint32_t)k8[10])<<16;     /* @fallthrough */
+    case 10: c+=k[4];                       /* @fallthrough@ */
+             b+=k[2]+(((uint32_t)k[3])<<16);
+             a+=k[0]+(((uint32_t)k[1])<<16);
+             break;
+    case 9 : c+=k8[8];                      /* @fallthrough */
+    case 8 : b+=k[2]+(((uint32_t)k[3])<<16);
+             a+=k[0]+(((uint32_t)k[1])<<16);
+             break;
+    case 7 : b+=((uint32_t)k8[6])<<16;      /* @fallthrough */
+    case 6 : b+=k[2];
+             a+=k[0]+(((uint32_t)k[1])<<16);
+             break;
+    case 5 : b+=k8[4];                      /* @fallthrough */
+    case 4 : a+=k[0]+(((uint32_t)k[1])<<16);
+             break;
+    case 3 : a+=((uint32_t)k8[2])<<16;      /* @fallthrough */
+    case 2 : a+=k[0];
+             break;
+    case 1 : a+=k8[0];
+             break;
+    case 0 : return c;  /* zero length strings require no mixing */
+    }
+
+  } else {                        /* need to read the key one byte at a time */
+    const uint8_t *k = (const uint8_t *)key;
+
+    /*--------------- all but the last block: affect some 32 bits of (a,b,c) */
+    while (length > 12)
+    {
+      a += k[0];
+      a += ((uint32_t)k[1])<<8;
+      a += ((uint32_t)k[2])<<16;
+      a += ((uint32_t)k[3])<<24;
+      b += k[4];
+      b += ((uint32_t)k[5])<<8;
+      b += ((uint32_t)k[6])<<16;
+      b += ((uint32_t)k[7])<<24;
+      c += k[8];
+      c += ((uint32_t)k[9])<<8;
+      c += ((uint32_t)k[10])<<16;
+      c += ((uint32_t)k[11])<<24;
+      mix(a,b,c);
+      length -= 12;
+      k += 12;
+    }
+
+    /*-------------------------------- last block: affect all 32 bits of (c) */
+    switch(length)                   /* all the case statements fall through */
+    {
+    case 12: c+=((uint32_t)k[11])<<24;
+    case 11: c+=((uint32_t)k[10])<<16;
+    case 10: c+=((uint32_t)k[9])<<8;
+    case 9 : c+=k[8];
+    case 8 : b+=((uint32_t)k[7])<<24;
+    case 7 : b+=((uint32_t)k[6])<<16;
+    case 6 : b+=((uint32_t)k[5])<<8;
+    case 5 : b+=k[4];
+    case 4 : a+=((uint32_t)k[3])<<24;
+    case 3 : a+=((uint32_t)k[2])<<16;
+    case 2 : a+=((uint32_t)k[1])<<8;
+    case 1 : a+=k[0];
+             break;
+    case 0 : return c;  /* zero length strings require no mixing */
+    }
+  }
+
+  final(a,b,c);
+  return c;             /* zero length strings require no mixing */
+}
+
+#elif HASH_BIG_ENDIAN == 1
+/*
+ * hashbig():
+ * This is the same as hashword() on big-endian machines.  It is different
+ * from hashlittle() on all machines.  hashbig() takes advantage of
+ * big-endian byte ordering.
+ */
+uint32_t hash_lookup3( const void *key, size_t length, const uint32_t initval)
+{
+  uint32_t a,b,c;
+  union { const void *ptr; size_t i; } u; /* to cast key to (size_t) happily */
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef + ((uint32_t)length) + initval;
+
+  u.ptr = key;
+  if (HASH_BIG_ENDIAN && ((u.i & 0x3) == 0)) {
+    const uint32_t *k = key;                           /* read 32-bit chunks */
+#ifdef VALGRIND
+    const uint8_t  *k8;
+#endif /* ifdef VALGRIND */
+
+    /*------ all but last block: aligned reads and affect 32 bits of (a,b,c) */
+    while (length > 12)
+    {
+      a += k[0];
+      b += k[1];
+      c += k[2];
+      mix(a,b,c);
+      length -= 12;
+      k += 3;
+    }
+
+    /*----------------------------- handle the last (probably partial) block */
+    /*
+     * "k[2]<<8" actually reads beyond the end of the string, but
+     * then shifts out the part it's not allowed to read.  Because the
+     * string is aligned, the illegal read is in the same word as the
+     * rest of the string.  Every machine with memory protection I've seen
+     * does it on word boundaries, so is OK with this.  But VALGRIND will
+     * still catch it and complain.  The masking trick does make the hash
+     * noticably faster for short strings (like English words).
+     */
+#ifndef VALGRIND
+
+    switch(length)
+    {
+    case 12: c+=k[2]; b+=k[1]; a+=k[0]; break;
+    case 11: c+=k[2]&0xffffff00; b+=k[1]; a+=k[0]; break;
+    case 10: c+=k[2]&0xffff0000; b+=k[1]; a+=k[0]; break;
+    case 9 : c+=k[2]&0xff000000; b+=k[1]; a+=k[0]; break;
+    case 8 : b+=k[1]; a+=k[0]; break;
+    case 7 : b+=k[1]&0xffffff00; a+=k[0]; break;
+    case 6 : b+=k[1]&0xffff0000; a+=k[0]; break;
+    case 5 : b+=k[1]&0xff000000; a+=k[0]; break;
+    case 4 : a+=k[0]; break;
+    case 3 : a+=k[0]&0xffffff00; break;
+    case 2 : a+=k[0]&0xffff0000; break;
+    case 1 : a+=k[0]&0xff000000; break;
+    case 0 : return c;              /* zero length strings require no mixing */
+    }
+
+#else  /* make valgrind happy */
+
+    k8 = (const uint8_t *)k;
+    switch(length)                   /* all the case statements fall through */
+    {
+    case 12: c+=k[2]; b+=k[1]; a+=k[0]; break;
+    case 11: c+=((uint32_t)k8[10])<<8;  /* fall through */
+    case 10: c+=((uint32_t)k8[9])<<16;  /* fall through */
+    case 9 : c+=((uint32_t)k8[8])<<24;  /* fall through */
+    case 8 : b+=k[1]; a+=k[0]; break;
+    case 7 : b+=((uint32_t)k8[6])<<8;   /* fall through */
+    case 6 : b+=((uint32_t)k8[5])<<16;  /* fall through */
+    case 5 : b+=((uint32_t)k8[4])<<24;  /* fall through */
+    case 4 : a+=k[0]; break;
+    case 3 : a+=((uint32_t)k8[2])<<8;   /* fall through */
+    case 2 : a+=((uint32_t)k8[1])<<16;  /* fall through */
+    case 1 : a+=((uint32_t)k8[0])<<24; break;
+    case 0 : return c;
+    }
+
+#endif /* !VALGRIND */
+
+  } else {                        /* need to read the key one byte at a time */
+    const uint8_t *k = key;
+
+    /*--------------- all but the last block: affect some 32 bits of (a,b,c) */
+    while (length > 12)
+    {
+      a += ((uint32_t)k[0])<<24;
+      a += ((uint32_t)k[1])<<16;
+      a += ((uint32_t)k[2])<<8;
+      a += ((uint32_t)k[3]);
+      b += ((uint32_t)k[4])<<24;
+      b += ((uint32_t)k[5])<<16;
+      b += ((uint32_t)k[6])<<8;
+      b += ((uint32_t)k[7]);
+      c += ((uint32_t)k[8])<<24;
+      c += ((uint32_t)k[9])<<16;
+      c += ((uint32_t)k[10])<<8;
+      c += ((uint32_t)k[11]);
+      mix(a,b,c);
+      length -= 12;
+      k += 12;
+    }
+
+    /*-------------------------------- last block: affect all 32 bits of (c) */
+    switch(length)                   /* all the case statements fall through */
+    {
+    case 12: c+=k[11];
+    case 11: c+=((uint32_t)k[10])<<8;
+    case 10: c+=((uint32_t)k[9])<<16;
+    case 9 : c+=((uint32_t)k[8])<<24;
+    case 8 : b+=k[7];
+    case 7 : b+=((uint32_t)k[6])<<8;
+    case 6 : b+=((uint32_t)k[5])<<16;
+    case 5 : b+=((uint32_t)k[4])<<24;
+    case 4 : a+=k[3];
+    case 3 : a+=((uint32_t)k[2])<<8;
+    case 2 : a+=((uint32_t)k[1])<<16;
+    case 1 : a+=((uint32_t)k[0])<<24;
+             break;
+    case 0 : return c;
+    }
+  }
+
+  final(a,b,c);
+  return c;
+}
+#else /* HASH_XXX_ENDIAN == 1 */
+#error Must define HASH_BIG_ENDIAN or HASH_LITTLE_ENDIAN
+#endif /* HASH_XXX_ENDIAN == 1 */

--- a/test/bstring/check_bstring.c
+++ b/test/bstring/check_bstring.c
@@ -96,29 +96,6 @@ START_TEST(test_compare)
 }
 END_TEST
 
-START_TEST(test_strcmp)
-{
-    ck_assert(str2cmp("an", 'a', 'n'));
-    ck_assert(str3cmp("old", 'o', 'l', 'd'));
-    ck_assert(str4cmp("farm", 'f', 'a', 'r', 'm'));
-    ck_assert(str5cmp("EIEIO", 'E', 'I', 'E', 'I', 'O'));
-    ck_assert(str6cmp("horses", 'h', 'o', 'r', 's', 'e', 's'));
-    ck_assert(str7cmp("beavers", 'b', 'e', 'a', 'v', 'e', 'r', 's'));
-    ck_assert(str8cmp("McDonald", 'M', 'c', 'D', 'o', 'n', 'a', 'l', 'd'));
-    ck_assert(str9cmp("elephants", 'e', 'l', 'e', 'p', 'h', 'a', 'n', 't',
-                's'));
-    ck_assert(str10cmp("everywhere", 'e', 'v', 'e', 'r', 'y', 'w', 'h', 'e',
-                'r', 'e'));
-    ck_assert(str11cmp("polar bears", 'p', 'o', 'l', 'a', 'r', ' ', 'b', 'e',
-                'a', 'r', 's'));
-    ck_assert(str12cmp("snow leopard", 's', 'n', 'o', 'w', ' ', 'l', 'e', 'o',
-                'p', 'a', 'r', 'd'));
-    ck_assert(!str12cmp("pocket mouse", 's', 'n', 'o', 'w', ' ', 'l', 'e', 'o',
-                'p', 'a', 'r', 'd'));
-}
-END_TEST
-
-
 START_TEST(test_atou64)
 {
     uint64_t val;
@@ -188,7 +165,6 @@ bstring_suite(void)
     tcase_add_test(tc_bstring, test_duplicate);
     tcase_add_test(tc_bstring, test_copy);
     tcase_add_test(tc_bstring, test_compare);
-    tcase_add_test(tc_bstring, test_strcmp);
     tcase_add_test(tc_bstring, test_atou64);
     tcase_add_test(tc_bstring, test_bstring_alloc_and_free);
 


### PR DESCRIPTION
Reverts twitter/ccommon#177
Looking into test failure with rust code