### PR TITLE
Reorder dependency includes in cmake, don't parallel build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 project(ccommon C)
 
+set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 1)
+
 enable_testing()
 
 ###################
@@ -157,6 +159,18 @@ include_directories(
     "${PROJECT_BINARY_DIR}"
     "include")
 
+###################
+# things to build #
+###################
+
+add_subdirectory(src)
+
+if(CHECK_WORKING)
+    include_directories(${include_directories} "${CHECK_INCLUDES}")
+    add_subdirectory(test)
+endif(CHECK_WORKING)
+
+
 if(HAVE_RUST)
     enable_language(Rust)
     include(CMakeCargo)
@@ -164,16 +178,6 @@ if(HAVE_RUST)
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DHAVE_RUST=1")
 endif()
 
-
-###################
-# things to build #
-###################
-
-add_subdirectory(src)
-if(CHECK_WORKING)
-    include_directories(${include_directories} "${CHECK_INCLUDES}")
-    add_subdirectory(test)
-endif(CHECK_WORKING)
 
 ###################
 # print a summary #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 project(ccommon C)
 
-set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 1)
+# Uncomment the following to output dependency graph debugging messages
+# set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 1)
 
 enable_testing()
 

--- a/ci/local-run.sh
+++ b/ci/local-run.sh
@@ -48,7 +48,7 @@ BUILD_DIR="${BUILD_DIR:-$TEMP}"
 mkdir -p "$BUILD_DIR" && (
   cd "$BUILD_DIR" &&
   cmake "${CMAKEFLAGS[@]}" "$TOPLEVEL" &&
-  make -j all &&
+  make all &&
   make check &&
   cd rust &&
   cargo test


### PR DESCRIPTION
Problem

Build was failing

Solution

Reorder dependencies in top-level CMakeLists.txt, also don't do `make -j` in the ci script.

Result

The build will run
