### PR TITLE
Simplify rust options, specify fewer output targets

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,8 +8,8 @@ members = [
 [profile.release]
 opt-level = 3
 debug = true
-rpath = false
-lto = true
+# rpath = false
+# lto = true
 debug-assertions = false
 codegen-units = 1
 

--- a/rust/cc_binding/Cargo.toml
+++ b/rust/cc_binding/Cargo.toml
@@ -9,4 +9,3 @@ failure = "~0.1.1"
 
 [lib]
 name = "cc_binding"
-crate-type = ["rlib", "dylib", "staticlib", "lib"]

--- a/rust/ccommon_rs/Cargo.toml
+++ b/rust/ccommon_rs/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jonathan Simms <jsimms@twitter.com>"]
 
 [lib]
 name = "ccommon_rs"
-crate-type = ["lib", "dylib", "rlib", "staticlib"]
+crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 


### PR DESCRIPTION
Problem

Rust build is too naively customized, causing the build to fail when integrated into pelikan

Solution

Use only `lib` and `staticlib` outputs, and use the defaults for `LTO` and `rpath` options.

Result

When integrated into pelikan, the cdb extension builds.