### PR TITLE
backport changes made to ccommon in pelikan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,16 +140,15 @@ endif(COVERAGE)
 include(FindPackageHandleStandardArgs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
-find_package(Check)
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(CHECK QUIET check>=0.10)
+endif()
+
 if(NOT CHECK_FOUND)
-    message(WARNING "Check is required to build and run tests")
-endif(NOT CHECK_FOUND)
-if(CHECK_FOUND)
-    check_symbol_exists(ck_assert_int_eq check.h CHECK_WORKING)
-    if(NOT CHECK_WORKING)
-        message(WARNING "Check version too old to build tests")
-    endif(NOT CHECK_WORKING)
-endif(CHECK_FOUND)
+    find_package(Check QUIET 0.10)
+endif()
 
 find_package(Threads)
 
@@ -166,10 +165,10 @@ include_directories(
 
 add_subdirectory(src)
 
-if(CHECK_WORKING)
-    include_directories(${include_directories} "${CHECK_INCLUDES}")
+if(CHECK_FOUND)
+    include_directories(${include_directories} ${CHECK_INCLUDES})
     add_subdirectory(test)
-endif(CHECK_WORKING)
+endif(CHECK_FOUND)
 
 
 if(HAVE_RUST)
@@ -193,4 +192,4 @@ message(STATUS "HAVE_SIGNAME: " ${HAVE_SIGNAME})
 
 message(STATUS "HAVE_BACKTRACE: " ${HAVE_BACKTRACE})
 
-message(STATUS "CHECK_WORKING: " ${CHECK_WORKING})
+message(STATUS "CHECK_FOUND: " ${CHECK_FOUND})

--- a/include/cc_mm.h
+++ b/include/cc_mm.h
@@ -66,6 +66,9 @@ extern "C" {
 #define cc_munmap(_p, _s)                                       \
     _cc_munmap(_p, (size_t)(_s), __FILE__, __LINE__)
 
+#define cc_alloc_usable_size(_p)                                \
+    _cc_alloc_usable_size(_p, __FILE__, __LINE__)
+
 void * _cc_alloc(size_t size, const char *name, int line);
 void * _cc_zalloc(size_t size, const char *name, int line);
 void * _cc_calloc(size_t nmemb, size_t size, const char *name, int line);
@@ -74,6 +77,7 @@ void * _cc_realloc_move(void *ptr, size_t size, const char *name, int line);
 void _cc_free(void *ptr, const char *name, int line);
 void * _cc_mmap(size_t size, const char *name, int line);
 int _cc_munmap(void *p, size_t size, const char *name, int line);
+size_t _cc_alloc_usable_size(void *ptr, const char *name, int line);
 
 #ifdef __cplusplus
 }

--- a/src/cc_mm.c
+++ b/src/cc_mm.c
@@ -27,6 +27,10 @@
 /* TODO(yao): detect OS in one place and use one variable everywhere */
 #if defined(__APPLE__) && defined(__MACH__)
 #   define MAP_ANONYMOUS MAP_ANON
+#include <malloc/malloc.h>
+#define malloc_usable_size malloc_size
+#else
+#include <malloc.h>
 #endif
 
 void *
@@ -166,4 +170,11 @@ _cc_munmap(void *p, size_t size, const char *name, int line)
     }
 
     return status;
+}
+
+size_t
+_cc_alloc_usable_size(void *ptr, const char *name, int line)
+{
+    log_vverb("malloc_usable_size(%p) @ %s:%d", ptr, name, line);
+    return malloc_usable_size(ptr);
 }


### PR DESCRIPTION
Problem

ccommon changes were made with the latest pmem changes in Pelikan, but those changes were not committed upstream.

Solution

Committing the same changes to the upstream ccommon repo (here).

