### PR TITLE
Fix TAILQ_REINIT

### DIFF
--- a/include/cc_queue.h
+++ b/include/cc_queue.h
@@ -694,8 +694,7 @@ struct {                                                                \
 
 #define TAILQ_REINIT(head, var, field, offset) do {                     \
     TAILQ_FIRST((head)) = var;                                          \
-    *(head)->tqh_last = NULL;                                           \
-    TAILQ_FOREACH(var, head, s_tqe) {                                   \
+    TAILQ_FOREACH(var, head, field) {                                   \
         if ((TAILQ_NEXT((var), field)) != NULL) {                       \
             TAILQ_NEXT((var), field) =                                  \
                 (void *)((char *)(TAILQ_NEXT((var), field)) + (offset));\
@@ -706,6 +705,7 @@ struct {                                                                \
             (var)->field.tqe_prev =                                     \
                 (void *)((char *)((var)->field.tqe_prev) + (offset));   \
         }                                                               \
+        (head)->tqh_last = &TAILQ_NEXT((var), field);                   \
     }                                                                   \
 } while (0)
 


### PR DESCRIPTION
- replace hardcoded value with "field" to work as general solution
- fix setting last element *(head)->tqh_last = NULL; sets the first
element to NULL, set last element while traverse whole tailq

Ref: twitter/pelikan#221
Commit: https://github.com/twitter/pelikan/pull/221/commits/095a02720e2415b8ff9bca497798dbbcd4a4209a

