### PR TITLE
Update Cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 project(ccommon C)
 
 # Uncomment the following to output dependency graph debugging messages


### PR DESCRIPTION
To be consistent with README file, which describe prerequisites as:

"To use cmake, make sure you already have it installed and the version is above **2.8**"
