### PR TITLE
Fix now_ns()

### DIFF
--- a/src/time/cc_timer_linux.c
+++ b/src/time/cc_timer_linux.c
@@ -172,7 +172,7 @@ _now_ns(void)
 {
     struct timespec now;
 
-    _gettime(&now, cid[DURATION_PRECISE]);
+    _gettime(&now, DURATION_PRECISE);
     return now.tv_sec * NSEC_PER_SEC + now.tv_nsec;
 }
 


### PR DESCRIPTION
- _gettime takes duration_type as parameter not clockid_t

Fix regression in #192 
Ref: twitter/pelikan#220