### PR TITLE
Add basic support of build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,12 +115,23 @@ configure_file(
 # set compiler flags
 # string concat is easier in 3.0, but older versions don't have the concat subcommand
 # so we are using list as input until we move to new version
-# TODO add build types
 add_definitions(-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64)
+# Set a default build type (Release) if none was specified
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+endif()
+
 set(CMAKE_MACOSX_RPATH 1)
 set(CFLAGS_LIST
     "-std=c11 "
-    "-ggdb3 -O2 "
+    "-ggdb3 "
     "-Wall "
     "-Wmissing-prototypes -Wmissing-declarations -Wredundant-decls "
     "-Wunused-function -Wunused-value -Wunused-variable "
@@ -133,7 +144,10 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 if (COVERAGE)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -Wall -W -fprofile-arcs -ftest-coverage")
+    if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
+        message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading" )
+    endif()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
 endif(COVERAGE)
 
 # test dependencies
@@ -183,6 +197,8 @@ endif()
 ###################
 # print a summary #
 ###################
+
+message(STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
 
 message(STATUS "PLATFORM: " ${OS_PLATFORM})
 

--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-rm -rf lcov _build _bin && mkdir _build && pushd _build && cmake -DCOVERAGE=on .. && make -j && make test && popd
+rm -rf lcov _build _bin && mkdir _build && pushd _build && cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=on .. && make -j && make test && popd
 mkdir lcov
 lcov --directory . --capture --output-file lcov/app.info
 genhtml lcov/app.info -o lcov/html


### PR DESCRIPTION
- debug build type to pass O0 flag, other to pass O2 flag
- remove unnecessary flags from COVERAGE like -g (ggdb3 is already passed) -Wall -W

Problem

The intention was to have convenient way to pass O0 flag - useful for debugging during development.

Solution

Add possibility to pass optimization flag via Build type in Cmake

@thinkingfish 
Let me know what you think about this solution - I could provide something similar to pelikan repository
