### PR TITLE
cc_option simplify _allowed_in_name

### DIFF
--- a/src/cc_option.c
+++ b/src/cc_option.c
@@ -441,8 +441,7 @@ static inline bool
 _allowed_in_name(char c)
 {
     /* the criteria is C's rules on variable names since we use it as such */
-    if ((c >= 'a' && c <= 'z') || c == '_' || (c >= 'A' && c <= 'Z') ||
-        (c >= '0' && c <= '9')) {
+    if (isalnum(c) || c == '_') {
         return true;
     } else {
         return false;


### PR DESCRIPTION
- simplify check by usage of isalnum to determine if character is alphanumeric