### PR TITLE
cc_bstring simplify and fix

### DIFF
--- a/src/cc_bstring.c
+++ b/src/cc_bstring.c
@@ -140,7 +140,7 @@ bstring_atoi64(int64_t *i64, struct bstring *str)
         // overflow check
         if (offset == CC_INT64_MAXLEN - 2) {
             if (sign < 0 && *i64 == INT64_MIN / 10 &&
-                    c - '0' > (uint64_t)(-INT64_MIN) % 10) {
+                    c - '0' > -(INT64_MIN % 10)) {
                 return CC_ERROR;
             }
             if (sign > 0 && *i64 == INT64_MAX / 10 &&

--- a/src/cc_bstring.c
+++ b/src/cc_bstring.c
@@ -20,6 +20,8 @@
 #include <cc_debug.h>
 #include <cc_mm.h>
 
+#include <ctype.h>
+
 /*
  * Byte string (struct bstring) is a sequence of unsigned char
  * The length of the string is pre-computed and explicitly available.
@@ -131,7 +133,7 @@ bstring_atoi64(int64_t *i64, struct bstring *str)
 
     for (*i64 = 0LL; offset < str->len; offset++) {
         c = *(str->data + offset);
-        if (c < '0' || c > '9') {
+        if (isdigit(c) == 0) {
             return CC_ERROR;
         }
 
@@ -167,7 +169,7 @@ bstring_atou64(uint64_t *u64, struct bstring *str)
 
     for (offset = 0; offset < str->len; offset++) {
         c = *(str->data + offset);
-        if (c < '0' || c > '9') {
+        if (isdigit(c) == 0) {
             return CC_ERROR;
         }
 


### PR DESCRIPTION
- use isdigit function instead of manual checking for digits

- fix integer overflow in expression -INT64_MIN ( see https://wandbox.org/nojs/clang-6.0.0/permlink/i1zE4BsgBYaiI78j )