### PR TITLE
continue on server socket on non-blocking errors

### DIFF
--- a/src/channel/cc_tcp.c
+++ b/src/channel/cc_tcp.c
@@ -340,7 +340,7 @@ _tcp_accept(struct tcp_conn *sc)
 
             log_error("accept on sd %d failed: %s", sc->sd, strerror(errno));
             INCR(tcp_metrics, tcp_accept_ex);
-            return -1;
+            continue;
         }
 
         break;


### PR DESCRIPTION
Problem

Accept returns upon non-blocking error, which means we may leave read-for-accept/close sockets in the queue.

Solution

continue on all non-blocking errors.

Result

draining the server socket queue properly.
