### PR TITLE
fix a bug and change how check is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,16 +153,16 @@ endif(COVERAGE)
 # test dependencies
 include(FindPackageHandleStandardArgs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
-
-find_package(PkgConfig QUIET)
-
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(CHECK QUIET check>=0.10)
-endif()
-
+find_package(Check)
 if(NOT CHECK_FOUND)
-    find_package(Check QUIET 0.10)
-endif()
+    message(WARNING "Check is required to build and run tests")
+endif(NOT CHECK_FOUND)
+if(CHECK_FOUND)
+    check_symbol_exists(ck_assert_int_eq check.h CHECK_WORKING)
+    if(NOT CHECK_WORKING)
+        message(WARNING "Check version too old to build tests")
+    endif(NOT CHECK_WORKING)
+endif(CHECK_FOUND)
 
 if (HAVE_ITT_INSTRUMENTATION)
     if(PKG_CONFIG_FOUND)
@@ -195,14 +195,12 @@ if(CHECK_FOUND)
     add_subdirectory(test)
 endif(CHECK_FOUND)
 
-
 if(HAVE_RUST)
     enable_language(Rust)
     include(CMakeCargo)
     add_subdirectory(rust)
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DHAVE_RUST=1")
 endif()
-
 
 ###################
 # print a summary #

--- a/src/channel/cc_tcp.c
+++ b/src/channel/cc_tcp.c
@@ -467,7 +467,7 @@ tcp_reject_all(struct tcp_conn *sc)
             log_error("accept on sd %d failed: %s", sc->sd, strerror(errno));
             INCR(tcp_metrics, tcp_reject_ex);
 
-            return -1;
+            return;
         }
 
         ret = close(sd);


### PR DESCRIPTION
Problem

There was a bug in the previous merge. And `check` library installed at non-standard location cannot be found.

Solution

Change to Pelikan's check-finding script. Fix bug.

