### PR TITLE
Fix failed test detection

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -21,7 +21,7 @@ export RUST_BACKTRACE=full
 mkdir -p _build && ( cd _build && "${cmake_cmd[@]}" .. && make && make test )
 RESULT=$?
 
-egrep -r ":F:|:E:" . |grep -v 'Binary file' || true
+egrep -r ":F:|:E:" _build/test |grep -v 'Binary file' || true
 
 
 if [[ $RESULT -ne 0 ]]; then


### PR DESCRIPTION
- limit grep log_test only for ccommon

Intention is to avoid messages in travis log not related with ccommon:

> ./_build/check/share/info/check.info:     check_money.c:9:F:Core:test_money_create:0: Assertion 'money_amount (m)==5' failed:
> ./_build/check/share/info/check.info:     check_money.c:5:E:Core:test_money_create:0: (after this point)
> ./_build/check/share/info/check.info:     ex_log_output.c:14:F:Core:test_fail: Failure
> ./_build/check/share/info/check.info:     ex_log_output.c:18:E:Core:test_exit: (after this point) Early exit

E.g.: https://travis-ci.org/twitter/ccommon/jobs/584280440