### PR TITLE
Expand rust bindings to add options, metrics, and ccbox

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "cc_binding",
     "ccommon_rs",
+    "ccommon-derive"
 ]
 
 [profile.release]

--- a/rust/cc_binding/build.rs
+++ b/rust/cc_binding/build.rs
@@ -112,6 +112,9 @@ fn main() {
         .prepend_enum_name(false)
         .whitelist_recursively(false)
 
+        // We provide a custom binding of metric with atomic types
+        .blacklist_type("metric")
+
         // All public types, variables and, functions exported by ccommon
         .whitelist_type("u?intmax_t")
         .whitelist_type("u?int([0-9]+)_t")

--- a/rust/cc_binding/src/lib.rs
+++ b/rust/cc_binding/src/lib.rs
@@ -29,11 +29,21 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
+#[path = "metric.rs"]
+mod metric_impl;
+
+pub use self::metric_impl::{metric, metric_anon_union};
+
 use libc::{addrinfo, timespec, FILE};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 pub const DEBUG_LOG_FILE: *mut i8 = std::ptr::null_mut();
+
+/// default log file
+pub const STATS_LOG_FILE: *mut i8 = std::ptr::null_mut();
+/// default log buf size
+pub const STATS_LOG_NBUF: u32 = 0;
 
 // Option methods
 pub unsafe fn option_bool(opt: *mut option) -> bool {

--- a/rust/cc_binding/src/metric.rs
+++ b/rust/cc_binding/src/metric.rs
@@ -1,3 +1,18 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::mem::{align_of, size_of, MaybeUninit};
 use std::os::raw::c_char;
 
@@ -26,6 +41,7 @@ impl metric_anon_union {
 
         (&self.bytes).align_to().1.as_ptr()
     }
+    
     pub unsafe fn as_mut_ptr<T>(&mut self) -> *mut T {
         assert!(align_of::<T>() <= align_of::<Self>());
         assert!(size_of::<T>() <= size_of::<Self>());

--- a/rust/cc_binding/src/metric.rs
+++ b/rust/cc_binding/src/metric.rs
@@ -1,0 +1,83 @@
+use std::mem::{align_of, size_of, MaybeUninit};
+use std::os::raw::c_char;
+
+use crate::metric_type_e;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct metric {
+    pub name: *mut c_char,
+    pub desc: *mut c_char,
+    pub type_: metric_type_e,
+    pub data: metric_anon_union,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union metric_anon_union {
+    bytes: [MaybeUninit<u8>; size_of::<u64>()],
+    _align: u64,
+}
+
+impl metric_anon_union {
+    pub unsafe fn as_ptr<T>(&self) -> *const T {
+        assert!(align_of::<T>() <= align_of::<Self>());
+        assert!(size_of::<T>() <= size_of::<Self>());
+
+        (&self.bytes).align_to().1.as_ptr()
+    }
+    pub unsafe fn as_mut_ptr<T>(&mut self) -> *mut T {
+        assert!(align_of::<T>() <= align_of::<Self>());
+        assert!(size_of::<T>() <= size_of::<Self>());
+
+        (&mut self.bytes).align_to_mut().1.as_mut_ptr()
+    }
+
+    fn uninit() -> Self {
+        Self {
+            bytes: [MaybeUninit::uninit(); size_of::<u64>()],
+        }
+    }
+
+    pub fn counter(val: u64) -> Self {
+        unsafe {
+            let mut x = Self::uninit();
+            std::ptr::write(x.as_mut_ptr(), val);
+            x
+        }
+    }
+
+    pub fn gauge(val: i64) -> Self {
+        unsafe {
+            let mut x = Self::uninit();
+            std::ptr::write(x.as_mut_ptr(), val);
+            x
+        }
+    }
+
+    pub fn fpn(val: f64) -> Self {
+        unsafe {
+            let mut x = Self::uninit();
+            std::ptr::write(x.as_mut_ptr(), val);
+            x
+        }
+    }
+}
+
+#[test]
+fn metric_anon_union_aligment_correct() {
+    assert_eq!(
+        std::mem::align_of::<metric_anon_union>(),
+        std::mem::align_of::<u64>()
+    );
+
+    assert_eq!(
+        std::mem::align_of::<metric_anon_union>(),
+        std::mem::align_of::<i64>()
+    );
+
+    assert_eq!(
+        std::mem::align_of::<metric_anon_union>(),
+        std::mem::align_of::<f64>()
+    );
+}

--- a/rust/cc_binding/src/metric.rs
+++ b/rust/cc_binding/src/metric.rs
@@ -41,7 +41,7 @@ impl metric_anon_union {
 
         (&self.bytes).align_to().1.as_ptr()
     }
-    
+
     pub unsafe fn as_mut_ptr<T>(&mut self) -> *mut T {
         assert!(align_of::<T>() <= align_of::<Self>());
         assert!(size_of::<T>() <= size_of::<Self>());

--- a/rust/ccommon-derive/Cargo.toml
+++ b/rust/ccommon-derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ccommon-derive"
+version = "0.1.0"
+authors = ["Sean Lynch <slynch@twitter.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.0", features = [ "parsing" ] }
+quote = "1.0.0"
+proc-macro2 = "1.0.0"
+proc-macro-crate = "0.1.4"

--- a/rust/ccommon-derive/src/attrs.rs
+++ b/rust/ccommon-derive/src/attrs.rs
@@ -1,0 +1,179 @@
+use syn::parse::*;
+use syn::*;
+use syn::punctuated::*;
+use syn::spanned::Spanned;
+use syn::parse_quote;
+use quote::ToTokens;
+use proc_macro2::TokenStream;
+
+use std::mem;
+
+pub struct AttrOption<T> {
+    pub name: Ident,
+    pub eq: Token![=],
+    pub val: T
+}
+
+pub type EqOption = AttrOption<Lit>;
+pub type ExprOption = AttrOption<Expr>;
+
+pub struct MetricAttr {
+    pub desc: EqOption,
+    pub name: Option<EqOption>,
+}
+
+pub struct OptionAttr {
+    pub desc: EqOption,
+    pub name: Option<EqOption>,
+    pub default: Option<ExprOption>,
+}
+
+enum StrOrExpr {
+    Str(LitStr),
+    Expr(Expr)
+}
+
+impl Parse for StrOrExpr {
+    fn parse(buf: &ParseBuffer) -> Result<Self> {
+        if buf.fork().parse::<LitStr>().is_ok() {
+            return Ok(StrOrExpr::Str(buf.parse()?));
+        }
+
+        buf.parse().map(StrOrExpr::Expr)
+    }
+}
+
+impl AttrOption<StrOrExpr> {
+    pub fn as_lit(self) -> Result<EqOption> {
+        match self.val {
+            StrOrExpr::Str(s) => Ok(EqOption {
+                name: self.name,
+                eq: self.eq,
+                val: Lit::Str(s)
+            }),
+            StrOrExpr::Expr(e) => Err(Error::new(
+                e.span(),
+                "Found expression, expected a literal string"
+            ))
+        }
+    }
+
+    pub fn as_expr(self) -> ExprOption {
+        let expr = match self.val {
+            StrOrExpr::Str(s) => parse_quote!(#s),
+            StrOrExpr::Expr(e) => e
+        };
+
+        ExprOption {
+            name: self.name,
+            eq: self.eq,
+            val: expr
+        }
+    }
+}
+
+impl<T: Parse> Parse for AttrOption<T> {
+    fn parse(buf: &ParseBuffer) -> Result<Self> {
+        Ok(Self {
+            name: buf.parse()?,
+            eq: buf.parse()?,
+            val: buf.parse()?
+        })
+    }
+}
+
+impl Parse for MetricAttr {
+    fn parse(buf: &ParseBuffer) -> Result<Self> {
+        let seq: Punctuated<EqOption, Token![,]> = Punctuated::parse_terminated(buf)?;
+
+        let mut desc = None;
+        let mut name = None;
+
+        for opt in seq {
+            let span = opt.name.span();
+            let param = opt.name.to_string();
+            let seen = match &*param {
+                "desc" => mem::replace(&mut desc, Some(opt)).is_some(),
+                "name" => mem::replace(&mut name, Some(opt)).is_some(),
+                _ => return Err(Error::new(
+                    opt.name.span(),
+                    format!("Unknown option `{}`", opt.name)
+                ))
+            };
+
+            if seen {
+                return Err(Error::new(
+                    span,
+                    format!("`{}` may only be specified once", param)
+                ));
+            }
+        }
+
+        let desc = match desc {
+            Some(x) => x,
+            None => return Err(buf.error("Expected a `desc` parameter here"))
+        };
+
+        Ok(Self { desc, name })
+    }
+}
+
+impl Parse for OptionAttr {
+    fn parse(buf: &ParseBuffer) -> Result<Self> {
+        let seq: Punctuated<AttrOption<StrOrExpr>, Token![,]> = Punctuated::parse_terminated(buf)?;
+
+        let mut desc = None;
+        let mut name = None;
+        let mut default = None;
+
+        for val in seq {
+            let span = val.span();
+            let param = val.name.to_string();
+            let seen = match &*param {
+                "desc" => mem::replace(&mut desc, Some(val.as_lit()?)).is_some(),
+                "name" => mem::replace(&mut name, Some(val.as_lit()?)).is_some(),
+                "default" => mem::replace(&mut default, Some(val.as_expr())).is_some(),
+                _ => return Err(Error::new(
+                    span,
+                    format!("Unknown option `{}`", param)
+                ))
+            };
+
+            if seen {
+                return Err(Error::new(
+                    span,
+                    format!("`{}` may only be specified once", param)
+                ));
+            }
+        }
+
+        let desc = match desc {
+            Some(x) => x,
+            None => return Err(buf.error("Expected a `desc` parameter here"))
+        };
+
+        Ok(Self {
+            desc,
+            name,
+            default,
+        })
+    }
+}
+
+
+impl<T: ToTokens> ToTokens for AttrOption<T> {
+    fn to_tokens(&self, stream: &mut TokenStream) {
+        self.name.to_tokens(stream);
+        self.eq.to_tokens(stream);
+        self.val.to_tokens(stream);
+    }
+}
+
+impl ToTokens for StrOrExpr {
+    fn to_tokens(&self, stream: &mut TokenStream) {
+        match self {
+            Self::Str(s) => s.to_tokens(stream),
+            Self::Expr(e) => e.to_tokens(stream)
+        }
+    }
+}

--- a/rust/ccommon-derive/src/lib.rs
+++ b/rust/ccommon-derive/src/lib.rs
@@ -1,0 +1,551 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Derive macros for `ccommon_rs`
+
+extern crate proc_macro;
+
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{
+    parse_macro_input, Attribute, Data, DeriveInput, Error, Expr, Fields, Generics, Ident, Lit,
+    LitStr,
+};
+
+/// Derive macro for `Metrics`.
+/// 
+/// Fields in the struct attempting to use this derive macro
+/// must either implement `SingleMetric` or `Metrics`. This is
+/// decided upon based on the field being decorated with the
+/// `desc` attribute.
+/// 
+/// # Example
+/// ```rust,ignore
+/// #[derive(Metrics)]
+/// struct MyMetrics {
+///     // This metric will have a name of `metric1` and a description
+///     // of `"The first metric"`.
+///     // This field requires that `Gauge` implements `SingleMetric`.
+///     #[desc = "The first metric"]
+///     metric1: Gauge,
+///     
+///     // This metric will have a name of `mymetric.metric2` and a
+///     // a description of `"The second metric"`.
+///     // This field requires that `Counter` implements `SingleMetric`.
+///     #[desc = "The second metric"]
+///     #[name = "mymetric.metric2"]
+///     metric2: Counter
+/// }
+/// 
+/// #[derive(Metrics)]
+/// struct OtherMetrics {
+///     // This field must implement `Metrics`
+///     my_metrics: MyMetrics
+/// }
+/// ```
+#[proc_macro_derive(Metrics, attributes(desc, name))]
+pub fn derive_metrics(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(stream as DeriveInput);
+
+    match derive_metrics_impl(input) {
+        Ok(x) => x,
+        Err(e) => e.to_compile_error(),
+    }
+    .into()
+}
+
+/// Derive macro for `Options`.
+/// 
+/// Fields in the struct attempting to use this derive macro
+/// must either implement `SingleOption` or `Options`. Which
+/// one of these will be required is decided by whether the
+/// field is decorated by the `desc` attribute.
+/// 
+/// The following attributes can be used with this macro
+/// - `desc`: Sets the description of the field.
+/// - `name`: Overrides the name of the field, the default
+///     name is the name of the field within the struct.
+/// - `default`: Override the default value for the field.
+///     By default, this is `Default::default()` or `std::ptr::null_mut()`
+///     in the case of strings. This can be any valid rust expression
+///     that returns the correct type.
+/// 
+/// # Example
+/// ```rust,ignore
+/// #[derive(Options)]
+/// #[repr(C)]
+/// struct MyOptions {
+///     // This option will have a name of `options.option1`, a description
+///     // of `Option 1`, and a default value of `false`.
+///     #[desc = "Option 1"]
+///     #[name = "options.option1"]
+///     opt1: Bool,
+/// 
+///     #[desc = "Function result option"]
+///     #[default(example_factory_function())]
+///     opt2: UInt
+/// }
+/// 
+/// #[derive(Option)]
+/// #[repr(transparent)]
+/// struct OtherOptions {
+///     inner: MyOptions
+/// }
+/// ```
+#[proc_macro_derive(Options, attributes(desc, name, default))]
+pub fn derive_options(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(stream as DeriveInput);
+
+    match derive_options_impl(input) {
+        Ok(x) => x,
+        Err(e) => e.to_compile_error(),
+    }
+    .into()
+}
+
+fn derive_metrics_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
+    let krate = crate_name("ccommon_rs")?;
+
+    let data = match input.data {
+        Data::Struct(data) => data,
+        Data::Enum(data) => {
+            return Err(Error::new(
+                data.enum_token.span(),
+                "Can only derive Metrics for a struct",
+            ))
+        }
+        Data::Union(data) => {
+            return Err(Error::new(
+                data.union_token.span(),
+                "Can only derive Metrics for a struct",
+            ))
+        }
+    };
+
+    if !is_repr_c_or_transparent(&input.attrs) {
+        return Err(Error::new(
+            input.ident.span(),
+            format!(
+                "`{}` must be either #[repr(C)] or #[repr(transparent)] to implement Metrics",
+                input.ident
+            ),
+        ));
+    }
+
+    if has_generics(&input.generics) {
+        return Err(Error::new(
+            input.generics.span(),
+            "Cannot derive Metrics for a struct with generics",
+        ));
+    }
+
+    let ident = input.ident;
+    let initializer =
+        match data.fields {
+            Fields::Named(fields) => {
+                let initializers: Vec<_> = fields.named.iter()
+                .map(|field| {
+                    let ref ty = field.ty;
+                    let ref name = field.ident;
+                    Ok(match get_description(&field.attrs)? {
+                        Some(desc) => {
+                            let desc = desc_to_c_str(desc);
+                            let namestr = match get_name(&field.attrs)? {
+                                Some(name) => desc_to_c_str(name),
+                                None => desc_to_c_str(name_as_lit(field.ident.clone().unwrap()))
+                            };
+
+                            quote! {
+                                #name: <#ty as #krate::metric::SingleMetric>::new(#namestr, #desc)
+                            }
+                        },
+                        None => quote! {
+                            #name: <#ty as #krate::metric::Metrics>::new()
+                        }
+                    })
+                })
+                .collect::<Result<_, Error>>()?;
+
+                quote! {
+                    Self {
+                        #( #initializers, )*
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let initializers: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(i, field)| {
+                        let ref ty = field.ty;
+                        Ok(match get_description(&field.attrs)? {
+                            Some(desc) => {
+                                let desc = desc_to_c_str(desc);
+                                let namestr = match get_name(&field.attrs)? {
+                                    Some(name) => desc_to_c_str(name),
+                                    None => desc_to_c_str(Lit::Str(LitStr::new(
+                                        &format!("{}", i),
+                                        field.span(),
+                                    ))),
+                                };
+
+                                quote! {
+                                    <#ty as #krate::metric::SingleMetric>::new(#namestr, #desc)
+                                }
+                            }
+                            None => quote! {
+                                <#ty as #krate::metric::Metrics>::new()
+                            },
+                        })
+                    })
+                    .collect::<Result<_, Error>>()?;
+
+                quote! {
+                    Self (
+                        #( #initializers, )*
+                    )
+                }
+            }
+            Fields::Unit => quote!(Self),
+        };
+
+    Ok(quote! {
+        unsafe impl #krate::metric::Metrics for #ident {
+            fn new() -> Self {
+                #initializer
+            }
+        }
+    }
+    .into())
+}
+
+fn derive_options_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
+    let krate = crate_name("ccommon_rs")?;
+
+    let data = match input.data {
+        Data::Struct(data) => data,
+        Data::Enum(data) => {
+            return Err(Error::new(
+                data.enum_token.span(),
+                "Can only derive Metrics for a struct",
+            ))
+        }
+        Data::Union(data) => {
+            return Err(Error::new(
+                data.union_token.span(),
+                "Can only derive Metrics for a struct",
+            ))
+        }
+    };
+
+    if !is_repr_c_or_transparent(&input.attrs) {
+        return Err(Error::new(
+            input.ident.span(),
+            format!(
+                "`{}` must be either #[repr(C)] or #[repr(transparent)] to implement Metrics",
+                input.ident
+            ),
+        ));
+    }
+
+    if has_generics(&input.generics) {
+        return Err(Error::new(
+            input.generics.span(),
+            "Cannot derive Metrics for a struct with generics",
+        ));
+    }
+
+    let ident = input.ident;
+    let initializer = match data.fields {
+        Fields::Named(fields) => {
+            let initializers: Vec<_> = fields.named.iter()
+                .map(|field| {
+                    let ref ty = field.ty;
+                    let ref name = field.ident;
+                    Ok(match get_description(&field.attrs)? {
+                        Some(desc) => {
+                            let desc = desc_to_c_str(desc);
+                            let namestr = match get_name(&field.attrs)? {
+                                Some(name) => desc_to_c_str(name),
+                                None => desc_to_c_str(name_as_lit(field.ident.clone().unwrap()))
+                            };
+
+                            match get_default(&field.attrs)? {
+                                Some(default) => quote! {
+                                    #name: <#ty as #krate::option::SingleOption>::new(
+                                        #default,
+                                        #namestr,
+                                        #desc
+                                    )
+                                },
+                                None => quote! {
+                                    #name: <#ty as #krate::option::SingleOption>::defaulted(#namestr, #desc)
+                                }
+                            }
+                        },
+                        None => quote! {
+                            #name: <#ty as #krate::option::Options>::new()
+                        }
+                    })
+                })
+                .collect::<Result<_, Error>>()?;
+
+            quote! {
+                Self {
+                    #( #initializers, )*
+                }
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let initializers: Vec<_> = fields
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(i, field)| {
+                    let ref ty = field.ty;
+                    Ok(match get_description(&field.attrs)? {
+                        Some(desc) => {
+                            let desc = desc_to_c_str(desc);
+                            let namestr = match get_name(&field.attrs)? {
+                                Some(name) => desc_to_c_str(name),
+                                None => desc_to_c_str(Lit::Str(LitStr::new(
+                                    &format!("{}", i),
+                                    field.span(),
+                                ))),
+                            };
+
+                            match get_default(&field.attrs)? {
+                                Some(default) => quote! {
+                                    <#ty as #krate::option::SingleOption>::new(#default, #namestr, #desc)
+                                },
+                                None => quote!{
+                                    <#ty as #krate::option::SingleOption>::defaulted(#namestr, #desc)
+                                }
+                            }
+                        }
+                        None => quote! {
+                            <#ty as #krate::option::Options>::new()
+                        },
+                    })
+                })
+                .collect::<Result<_, Error>>()?;
+
+            quote! {
+                Self (
+                    #( #initializers, )*
+                )
+            }
+        }
+        Fields::Unit => quote!(Self),
+    };
+
+    Ok(quote! {
+        unsafe impl #krate::option::Options for #ident {
+            fn new() -> Self {
+                #initializer
+            }
+        }
+    }
+    .into())
+}
+
+fn crate_name(name: &'static str) -> Result<TokenStream, Error> {
+    if std::env::var("CARGO_PKG_NAME").unwrap() == "ccommon_rs" {
+        return Ok(quote! { ::ccommon_rs });
+    }
+
+    let name = match proc_macro_crate::crate_name(name) {
+        Ok(name) => name,
+        Err(e) => return Err(Error::new(Span::call_site(), e)),
+    };
+
+    let ident = Ident::new(&name, Span::call_site());
+
+    Ok(quote! { ::#ident })
+}
+
+fn name_as_lit(name: Ident) -> Lit {
+    Lit::Str(LitStr::new(&format!("{}", name), name.span()))
+}
+
+fn desc_to_c_str(desc: Lit) -> TokenStream {
+    use syn::LitByteStr;
+
+    let span = desc.span();
+
+    let mut value = match desc {
+        Lit::Str(lit) => lit.value().into_bytes(),
+        Lit::ByteStr(lit) => lit.value(),
+        _ => unreachable!(),
+    };
+
+    for &byte in &value {
+        if byte == b'\0' {
+            return quote_spanned! { span =>
+                compile_error!(
+                    "Description contained a nul character"
+                )
+            };
+        }
+    }
+
+    value.push(b'\0');
+
+    let lit = LitByteStr::new(&value, span);
+
+    quote! {
+        unsafe {
+            ::std::ffi::CStr::from_bytes_with_nul_unchecked(#lit)
+        }
+    }
+}
+
+fn get_default(attrs: &[Attribute]) -> Result<Option<Expr>, Error> {
+    for attr in attrs {
+        let ident = match attr.path.get_ident() {
+            Some(x) => x,
+            None => continue,
+        };
+
+        if ident != "default" {
+            continue;
+        }
+
+        return Ok(Some(attr.parse_args()?));
+    }
+
+    Ok(None)
+}
+fn get_description(attrs: &[Attribute]) -> Result<Option<Lit>, Error> {
+    use syn::Meta;
+
+    for attr in attrs {
+        let ident = match attr.path.get_ident() {
+            Some(x) => x,
+            None => continue,
+        };
+
+        if ident != "desc" {
+            continue;
+        }
+
+        let meta = attr.parse_meta()?;
+
+        let lit = match meta {
+            Meta::NameValue(meta) => meta.lit,
+            _ => {
+                return Err(Error::new(
+                    meta.span(),
+                    "Invalid attribute, expected `#[desc = <string-literal>]`",
+                ))
+            }
+        };
+
+        match lit {
+            Lit::Str(x) => return Ok(Some(Lit::Str(x))),
+            Lit::ByteStr(x) => return Ok(Some(Lit::ByteStr(x))),
+            lit => return Err(Error::new(lit.span(), "Expected a string literal")),
+        }
+    }
+
+    Ok(None)
+}
+fn get_name(attrs: &[Attribute]) -> Result<Option<Lit>, Error> {
+    use syn::Meta;
+
+    for attr in attrs {
+        let ident = match attr.path.get_ident() {
+            Some(x) => x,
+            None => continue,
+        };
+
+        if ident != "name" {
+            continue;
+        }
+
+        let meta = attr.parse_meta()?;
+
+        let lit = match meta {
+            Meta::NameValue(meta) => meta.lit,
+            _ => {
+                return Err(Error::new(
+                    meta.span(),
+                    "Invalid attribute, expected `#[name = <string-literal>]`",
+                ))
+            }
+        };
+
+        match lit {
+            Lit::Str(x) => return Ok(Some(Lit::Str(x))),
+            Lit::ByteStr(x) => return Ok(Some(Lit::ByteStr(x))),
+            lit => return Err(Error::new(lit.span(), "Expected a string literal")),
+        }
+    }
+
+    Ok(None)
+}
+
+fn is_repr_c_or_transparent(attrs: &[Attribute]) -> bool {
+    use syn::{Meta, NestedMeta};
+
+    fn is_correct_meta(nested: &NestedMeta) -> bool {
+        let meta = match nested {
+            NestedMeta::Meta(meta) => meta,
+            _ => return false,
+        };
+
+        let path = match meta {
+            Meta::Path(path) => path,
+            _ => return false,
+        };
+
+        let ident = match path.get_ident() {
+            Some(ident) => ident,
+            _ => return false,
+        };
+
+        ident == "C" || ident == "transparent"
+    }
+
+    for attr in attrs {
+        let ident = match attr.path.get_ident() {
+            Some(ident) => ident,
+            None => continue,
+        };
+
+        if ident != "repr" {
+            continue;
+        }
+
+        let list = match attr.parse_meta() {
+            Ok(Meta::List(list)) => list,
+            _ => continue,
+        };
+
+        for nested in &list.nested {
+            if is_correct_meta(nested) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+fn has_generics(generics: &Generics) -> bool {
+    return generics.lt_token.is_some() || generics.where_clause.is_some();
+}

--- a/rust/ccommon-derive/src/lib.rs
+++ b/rust/ccommon-derive/src/lib.rs
@@ -164,7 +164,7 @@ fn derive_metrics_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
             let ref name = field.ident;
             let label = match is_tuple {
                 true => quote! {},
-                false => quote! { #name: }
+                false => quote! { #name: },
             };
 
             Ok(match get_metric_attr(&field.attrs)? {
@@ -174,7 +174,9 @@ fn derive_metrics_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
                         Some(name) => to_c_str(&name.val),
                         None => match field.ident.as_ref() {
                             Some(name) => to_c_str(&name_as_lit(name)),
-                            None => to_c_str(&Lit::Str(LitStr::new(&format!("{}", i), field.span()))),
+                            None => {
+                                to_c_str(&Lit::Str(LitStr::new(&format!("{}", i), field.span())))
+                            }
                         },
                     };
 
@@ -275,7 +277,7 @@ fn derive_options_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
             let ref name = field.ident;
             let label = match is_tuple {
                 true => quote! {},
-                false => quote! { #name: }
+                false => quote! { #name: },
             };
 
             Ok(match get_option_attr(&field.attrs)? {
@@ -285,7 +287,9 @@ fn derive_options_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
                         Some(name) => to_c_str(&name.val),
                         None => match field.ident.as_ref() {
                             Some(name) => to_c_str(&name_as_lit(name)),
-                            None => to_c_str(&Lit::Str(LitStr::new(&format!("{}", i), field.span()))),
+                            None => {
+                                to_c_str(&Lit::Str(LitStr::new(&format!("{}", i), field.span())))
+                            }
                         },
                     };
 

--- a/rust/ccommon_rs/Cargo.toml
+++ b/rust/ccommon_rs/Cargo.toml
@@ -2,13 +2,18 @@
 name = "ccommon_rs"
 version = "0.1.0"
 authors = ["Jonathan Simms <jsimms@twitter.com>", "Sean Lynch <slynch@twitter.com>"]
+edition = "2018"
+
+[features]
+derive = [ "ccommon-derive" ]
+
+default = [ "derive" ]
 
 [lib]
 name = "ccommon_rs"
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-
 cc_binding = { path = "../cc_binding" }
 chrono = "~0.4.4"
 crossbeam = "~0.3.2"
@@ -22,3 +27,7 @@ tempfile = "~3.0"
 thread-id = "~3.3"
 thread_local = "~0.3.5"
 time = "~0.1"
+
+[dependencies.ccommon-derive]
+path = "../ccommon-derive"
+optional = true

--- a/rust/ccommon_rs/src/bstring.rs
+++ b/rust/ccommon_rs/src/bstring.rs
@@ -1,3 +1,18 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! BString is a wrapper around a foreign allocated and freed pointer to a cc_bstring.
 //! It takes care of creating and freeing the foreign pointer within the normal
 //! Rust lifetime rules. It has a companion reference object BStr, and the relation

--- a/rust/ccommon_rs/src/buf.rs
+++ b/rust/ccommon_rs/src/buf.rs
@@ -138,7 +138,7 @@ impl OwnedBuf {
     pub unsafe fn from_raw(buf: *mut buf) -> Self {
         Self { buf }
     }
-    
+
     pub fn into_raw(self) -> *mut buf {
         let buf = self.buf;
         // Don't want to run drop on the destructor

--- a/rust/ccommon_rs/src/ccbox.rs
+++ b/rust/ccommon_rs/src/ccbox.rs
@@ -38,7 +38,7 @@ unsafe impl<T: Sync + ?Sized> Sync for CCBox<T> {}
 
 impl<T> CCBox<T> {
     /// Create a new `CCBox` with `val` inside.
-    /// 
+    ///
     /// # Panics
     /// Panics if the underlying allocator fails to allocate
     /// or if `T` requires an alignment of greater than 16.
@@ -53,11 +53,11 @@ impl<T> CCBox<T> {
     }
 
     /// Attempt to create a new `CCBox` with `val` inside.
-    /// 
+    ///
     /// Since the underlying allocator does not support
     /// passing alignments, any allocation with alignment
-    /// greater than 16 will fail. 
-    /// 
+    /// greater than 16 will fail.
+    ///
     /// In addition, returns an error whenever the underlying
     /// allocator returns `NULL`.
     pub fn try_new(val: T) -> Result<CCBox<T>, AllocationError<T>> {
@@ -80,7 +80,7 @@ impl<T> CCBox<T> {
 
             Ok(CCBox(match NonNull::new(ptr as *mut T) {
                 Some(x) => x,
-                None => return Err(AllocationError::new())
+                None => return Err(AllocationError::new()),
             }))
         }
     }

--- a/rust/ccommon_rs/src/ccbox.rs
+++ b/rust/ccommon_rs/src/ccbox.rs
@@ -1,0 +1,180 @@
+use std::fmt;
+use std::mem::{self, MaybeUninit};
+use std::ops::*;
+use std::ptr::NonNull;
+
+use cc_binding::{_cc_alloc, _cc_free};
+
+macro_rules! c_str {
+    ($s:expr) => {
+        concat!($s, "\0").as_ptr() as *const i8
+    };
+}
+
+/// A box that allocates and frees using `cc_alloc`
+/// and `cc_free`.
+#[repr(transparent)]
+pub struct CCBox<T: ?Sized>(NonNull<T>);
+
+unsafe impl<T: Send + ?Sized> Send for CCBox<T> {}
+unsafe impl<T: Sync + ?Sized> Sync for CCBox<T> {}
+
+impl<T> CCBox<T> {
+    pub fn new(val: T) -> CCBox<T> {
+        // Most malloc implementations give 16-byte alignment
+        assert!(mem::align_of::<T>() <= 16);
+
+        match Self::try_new(val) {
+            Some(x) => x,
+            None => panic!("Failed to allocate memory"),
+        }
+    }
+
+    pub fn try_new(val: T) -> Option<CCBox<T>> {
+        if mem::size_of_val(&val) == 0 {
+            return Some(CCBox(NonNull::dangling()));
+        }
+
+        if mem::align_of_val(&val) > 16 {
+            return None;
+        }
+
+        unsafe {
+            let ptr = _cc_alloc(
+                mem::size_of_val(&val),
+                c_str!(module_path!()),
+                line!() as std::os::raw::c_int,
+            ) as *mut MaybeUninit<T>;
+
+            *ptr = MaybeUninit::new(val);
+
+            Some(CCBox(NonNull::new(ptr as *mut T)?))
+        }
+    }
+}
+
+impl<T: ?Sized> CCBox<T> {
+    /// Construct a `CCBox` from a raw pointer.
+    ///
+    /// After this function is called the raw pointer is owned by
+    /// the resulting `CCBox`. When the box is dropped, it will run
+    /// the destructor for the stored value and free the pointer
+    /// using [`_cc_free`](ccommon_sys::_cc_free).
+    ///
+    /// # Safety
+    /// For this to be safe the pointer must have been allocated
+    /// using [`_cc_alloc`](ccommon_sys::_cc_alloc). In addition,
+    /// calling `CCBox::from_raw`
+    pub unsafe fn from_raw(raw: *mut T) -> Self {
+        assert!(!raw.is_null());
+
+        CCBox(NonNull::new_unchecked(raw))
+    }
+
+    /// Comsumes the box and returns the pointer stored inside.
+    ///
+    /// The pointer should be freed using [`_cc_free`](ccommon_sys::_cc_free)
+    /// or by recreating a `CCBox` from the pointer.
+    pub fn into_raw(b: Self) -> *mut T {
+        let ptr = b.0.as_ptr();
+        // Don't want to free the pointer
+        mem::forget(b);
+        ptr
+    }
+}
+
+impl<T: ?Sized> Drop for CCBox<T> {
+    fn drop(&mut self) {
+        use std::ptr;
+
+        if mem::size_of_val(&**self) != 0 {
+            unsafe {
+                ptr::drop_in_place(self.0.as_ptr());
+
+                _cc_free(
+                    self.0.as_ptr() as *mut std::ffi::c_void,
+                    c_str!(module_path!()),
+                    line!() as std::os::raw::c_int,
+                );
+            }
+        }
+    }
+}
+
+impl<T: ?Sized> Deref for CCBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for CCBox<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { self.0.as_mut() }
+    }
+}
+
+impl<T: Default> Default for CCBox<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T: ?Sized> AsRef<T> for CCBox<T> {
+    fn as_ref(&self) -> &T {
+        &*self
+    }
+}
+
+impl<T: ?Sized> AsMut<T> for CCBox<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut *self
+    }
+}
+
+impl<T: Clone> Clone for CCBox<T> {
+    fn clone(&self) -> Self {
+        CCBox::new(self.as_ref().clone())
+    }
+}
+
+impl<T: fmt::Debug + ?Sized> fmt::Debug for CCBox<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(fmt)
+    }
+}
+
+impl<T: fmt::Display + ?Sized> fmt::Display for CCBox<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(fmt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ccbox_size_tests() {
+        use std::mem::size_of;
+
+        assert_eq!(size_of::<CCBox<()>>(), size_of::<*mut ()>());
+
+        assert_eq!(size_of::<Option<CCBox<()>>>(), size_of::<*mut ()>());
+    }
+
+    #[test]
+    fn ptr_round_trip() {
+        unsafe {
+            let ptr1 = _cc_alloc(16, c_str!("test"), 0);
+            let boxed = CCBox::from_raw(ptr1);
+            let ptr2 = CCBox::into_raw(boxed);
+
+            // Ensure the pointer is properly freed
+            let _boxed = CCBox::from_raw(ptr2);
+
+            assert_eq!(ptr1, ptr2);
+        }
+    }
+}

--- a/rust/ccommon_rs/src/error.rs
+++ b/rust/ccommon_rs/src/error.rs
@@ -1,0 +1,49 @@
+
+use std::fmt::{self, Formatter, Display};
+use std::error::Error as StdError;
+
+/// Error codes that could be returned by ccommon functions.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    Generic = -1,
+    EAgain = -2,
+    ERetry = -3,
+    ENoMem = -4,
+    EEmpty = -5,
+    ERdHup = -6,
+    EInval = -7,
+    EOther = -8,
+}
+
+impl From<std::os::raw::c_int> for Error {
+    fn from(val: std::os::raw::c_int) -> Self {
+        match val {
+            -1 => Error::Generic,
+            -2 => Error::EAgain,
+            -3 => Error::ERetry,
+            -4 => Error::ENoMem,
+            -5 => Error::EEmpty,
+            -6 => Error::ERdHup,
+            -7 => Error::EInval,
+            _ => Error::EOther,
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::Generic => write!(fmt, "Generic Error"),
+            Error::EAgain => write!(fmt, "EAGAIN"),
+            Error::ERetry => write!(fmt, "ERETRY"),
+            Error::ENoMem => write!(fmt, "ENOMEM"),
+            Error::EEmpty => write!(fmt, "EEMPTY"),
+            Error::ERdHup => write!(fmt, "ERDHUP"),
+            Error::EInval => write!(fmt, "EINVAL"),
+            Error::EOther => write!(fmt, "EOTHER")
+        }
+    }
+}
+
+impl StdError for Error {}

--- a/rust/ccommon_rs/src/lib.rs
+++ b/rust/ccommon_rs/src/lib.rs
@@ -54,7 +54,6 @@ mod ccbox;
 mod error;
 
 pub use self::ccbox::CCBox;
-pub use self::error::{Error, AllocationError};
+pub use self::error::{AllocationError, Error};
 
 pub type Result<T> = result::Result<T, failure::Error>;
-

--- a/rust/ccommon_rs/src/lib.rs
+++ b/rust/ccommon_rs/src/lib.rs
@@ -54,7 +54,7 @@ mod ccbox;
 mod error;
 
 pub use self::ccbox::CCBox;
-pub use self::error::Error;
+pub use self::error::{Error, AllocationError};
 
 pub type Result<T> = result::Result<T, failure::Error>;
 

--- a/rust/ccommon_rs/src/lib.rs
+++ b/rust/ccommon_rs/src/lib.rs
@@ -32,43 +32,29 @@ extern crate time;
 #[macro_use]
 extern crate rusty_fork;
 
+// Needed to allow derive macros within this crate
+extern crate self as ccommon_rs;
+
+#[cfg(feature = "derive")]
+pub use ccommon_derive::{Metrics, Options};
+
 use std::result;
 
 pub mod bstring;
 pub mod buf;
 pub mod log;
+pub mod metric;
+pub mod option;
 pub mod util;
 
 // like how guava provides enhancements for Int as "Ints"
 pub mod ptrs;
 
+mod ccbox;
+mod error;
+
+pub use self::ccbox::CCBox;
+pub use self::error::Error;
+
 pub type Result<T> = result::Result<T, failure::Error>;
 
-/// Error codes that could be returned by ccommon functions.
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub enum Error {
-    Generic = -1,
-    EAgain = -2,
-    ERetry = -3,
-    ENoMem = -4,
-    EEmpty = -5,
-    ERdHup = -6,
-    EInval = -7,
-    EOther = -8,
-}
-
-impl From<std::os::raw::c_int> for Error {
-    fn from(val: std::os::raw::c_int) -> Self {
-        match val {
-            -1 => Error::Generic,
-            -2 => Error::EAgain,
-            -3 => Error::ERetry,
-            -4 => Error::ENoMem,
-            -5 => Error::EEmpty,
-            -6 => Error::ERdHup,
-            -7 => Error::EInval,
-            _ => Error::EOther,
-        }
-    }
-}

--- a/rust/ccommon_rs/src/log/mod.rs
+++ b/rust/ccommon_rs/src/log/mod.rs
@@ -70,11 +70,11 @@
 #![allow(dead_code)]
 
 pub use super::Result;
-use bstring::BStr;
+use crate::bstring::BStr;
+use crate::ptrs;
 use cc_binding as bind;
 use crossbeam::sync::ArcCell;
 use failure;
-use ptrs;
 use rslog;
 pub use rslog::{Level, Log, SetLoggerError};
 use rslog::{Metadata, Record};
@@ -225,7 +225,7 @@ impl From<usize> for ModuleState {
 }
 
 #[cfg(test)]
-pub(in log) struct LogMetrics(*mut bind::log_metrics_st);
+pub(self) struct LogMetrics(*mut bind::log_metrics_st);
 
 #[cfg(test)]
 impl LogMetrics {

--- a/rust/ccommon_rs/src/metric.rs
+++ b/rust/ccommon_rs/src/metric.rs
@@ -1,0 +1,589 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types and methods for dealing with ccommon metrics.
+//! 
+//! To use this any collection of metrics (i.e. a struct containing metrics)
+//! should implement the `Metrics` trait through the derive macro. This
+//! will (usually) assert that the struct you are using is equivalent in
+//! memory to an array of `metric` structs.
+
+use std::ffi::CStr;
+use std::fmt;
+use std::ops::{AddAssign, SubAssign};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+use cc_binding::{
+    metric, metric_anon_union, metric_describe_all, metric_reset, METRIC_COUNTER, METRIC_FPN,
+    METRIC_GAUGE,
+};
+
+// Sealed trait to prevent SingleMetric from ever being implemented
+// from outside of this crate.
+mod private {
+    pub trait Sealed {}
+}
+
+/// A single metric value.
+///
+/// This trait is sealed and cannot be implemented outside
+/// of ccommon_rs.
+pub unsafe trait SingleMetric: self::private::Sealed {
+    /// Create a metric with the given description and name.
+    ///
+    /// Normally this should only be called by the
+    /// derive macro for `Metrics`.
+    fn new(name: &'static CStr, desc: &'static CStr) -> Self;
+
+    /// The metric's name
+    fn name(&self) -> &'static CStr;
+    /// The metric's description
+    fn desc(&self) -> &'static CStr;
+}
+
+/// A type that can be safely viewed as a contiguous array
+/// of [`metric`s][0].
+///
+/// It should usually only be implemented through `#[derive(Metrics)]`.
+/// However, it must be implemented manually for C types that have
+/// been bound through bindgen.
+///
+/// [0]: ../../cc_binding/struct.metric.html
+pub unsafe trait Metrics: Sized {
+    fn new() -> Self;
+}
+
+pub trait MetricExt: Metrics {
+    /// The number of metrics in this object when
+    /// it is interpreted as an array.
+    ///
+    /// # Panics
+    /// Panics if the size of this type is not a multiple
+    /// of the size of `metric`.
+    fn num_metrics() -> usize {
+        use std::mem::size_of;
+
+        // If this assert fails then there was no way that
+        // options upholds it's safety requirements so it's
+        // better to fail here.
+        assert!(size_of::<Self>() % size_of::<metric>() == 0);
+
+        // If this assert fails then we'll pass an invalid
+        // size to several ccommon methods.
+        assert!(size_of::<Self>() / size_of::<metric>() < std::u32::MAX as usize);
+
+        size_of::<Self>() / size_of::<metric>()
+    }
+
+    /// Get `self` as a const pointer to an array of `metric`s.
+    ///
+    /// # Panics
+    /// Panics if the size of this type is not a multiple
+    /// of the size of `metric`.
+    fn as_ptr(&self) -> *const metric {
+        assert!(std::mem::size_of::<Self>() % std::mem::size_of::<metric>() == 0);
+
+        self as *const _ as *const metric
+    }
+
+    /// Get `self` as a mutable pointer to an array of `metric`s.
+    ///
+    /// # Panics
+    /// Panics if the size of this type is not a multiple
+    /// of the size of `metric`.
+    fn as_mut_ptr(&mut self) -> *mut metric {
+        assert!(std::mem::size_of::<Self>() % std::mem::size_of::<metric>() == 0);
+
+        self as *mut _ as *mut metric
+    }
+
+    /// Print a description of all metricss in the current object
+    /// given using the name and description.
+    ///
+    /// Internally this calls out to `metric_describe_all`.
+    fn describe_all(&self) {
+        unsafe {
+            metric_describe_all(
+                // Note: ccommon uses a mutable pointer but it
+                //       should really be a const pointer.
+                self.as_ptr() as *mut _,
+                Self::num_metrics() as u32,
+            )
+        }
+    }
+
+    /// Reset all metrics to their default values.
+    /// 
+    /// This means that all 3 types of metrics are reset to 0.
+    /// 
+    /// Internally this calls out to `metric_reset`.
+    fn reset_all(&mut self) {
+        unsafe {
+            metric_reset(
+                self.as_mut_ptr(),
+                Self::num_metrics() as u32
+            )
+        }
+    }
+}
+
+impl<T: Metrics> MetricExt for T {}
+
+/// An atomic counter metric.
+///
+/// Exposes `incr` and `decr` operations that can also be
+/// used via operators `+=` and `-=`.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Counter(metric);
+
+impl Counter {
+    fn as_ref(&self) -> &AtomicU64 {
+        unsafe { &*self.0.data.as_ptr::<AtomicU64>() }
+    }
+
+    /// Increment the counter by `n` atomically.
+    pub fn incr_n(&self, n: u64) {
+        self.as_ref().fetch_add(n, Ordering::Relaxed);
+    }
+    
+    /// Increment the counter by `1` atomically.
+    pub fn incr(&self) {
+        self.incr_n(1)
+    }
+
+    /// Decrement the counter by `n` atomically.
+    pub fn decr_n(&self, n: u64) {
+        self.as_ref().fetch_sub(n, Ordering::Relaxed);
+    }
+
+    /// Decrement the counter by `1` atomically.
+    pub fn decr(&self) {
+        self.decr_n(1)
+    }
+
+    /// Atomically store a value in the counter.
+    pub fn update(&self, val: u64) {
+        self.as_ref().store(val, Ordering::Relaxed)
+    }
+
+    /// Atomically get the value out of the counter.
+    pub fn value(&self) -> u64 {
+        self.as_ref().load(Ordering::Relaxed)
+    }
+}
+
+impl self::private::Sealed for Counter {}
+
+unsafe impl SingleMetric for Counter {
+    fn new(name: &CStr, desc: &CStr) -> Self {
+        Self(metric {
+            name: name.as_ptr() as *mut i8,
+            desc: desc.as_ptr() as *mut i8,
+            type_: METRIC_COUNTER,
+            data: metric_anon_union::counter(0),
+        })
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.desc) }
+    }
+}
+
+impl fmt::Debug for Counter {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Counter")
+            .field("name", unsafe { &CStr::from_ptr(self.0.name as *const i8) })
+            .field("desc", unsafe { &CStr::from_ptr(self.0.desc as *const i8) })
+            .field("counter", &self.value())
+            .finish()
+    }
+}
+
+impl AddAssign<u64> for Counter {
+    fn add_assign(&mut self, val: u64) {
+        self.incr_n(val);
+    }
+}
+
+impl SubAssign<u64> for Counter {
+    fn sub_assign(&mut self, val: u64) {
+        self.decr_n(val);
+    }
+}
+
+/// A `f64` metric that can be updated atomically.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Fpn(metric);
+
+impl Fpn {
+    /// Get the value atomically.
+    pub fn value(&self) -> f64 {
+        unsafe { std::mem::transmute((*self.0.data.as_ptr::<AtomicU64>()).load(Ordering::Relaxed)) }
+    }
+
+    /// Update the value atomically.
+    pub fn update(&self, val: f64) {
+        unsafe {
+            (*self.0.data.as_ptr::<AtomicU64>()).store(std::mem::transmute(val), Ordering::Relaxed)
+        }
+    }
+}
+
+impl self::private::Sealed for Fpn {}
+
+unsafe impl SingleMetric for Fpn {
+    fn new(name: &CStr, desc: &CStr) -> Self {
+        Self(metric {
+            name: name.as_ptr() as *mut i8,
+            desc: desc.as_ptr() as *mut i8,
+            type_: METRIC_FPN,
+            data: metric_anon_union::gauge(0),
+        })
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.desc) }
+    }
+}
+
+impl fmt::Debug for Fpn {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Fpn")
+            .field("name", unsafe { &CStr::from_ptr(self.0.name as *const i8) })
+            .field("desc", unsafe { &CStr::from_ptr(self.0.desc as *const i8) })
+            .field("fpn", &self.value())
+            .finish()
+    }
+}
+
+/// A gauge metric that can be updated atomically.
+///
+/// Exposes `incr`, `decr`, and `update`. `incr` and `decr`
+/// can be used through operators `+=` and `-=`.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Gauge(metric);
+
+impl Gauge {
+    fn as_ref(&self) -> &AtomicI64 {
+        unsafe { &*self.0.data.as_ptr::<AtomicI64>() }
+    }
+
+    /// Increment the gauge atomically by `n`.
+    pub fn incr_n(&self, n: i64) {
+        self.as_ref().fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Increment the gauge atomically by `1`.
+    pub fn incr(&self) {
+        self.incr_n(1)
+    }
+
+    /// Decrement the gauge atomically by `n`.
+    pub fn decr_n(&self, n: i64) {
+        self.as_ref().fetch_sub(n, Ordering::Relaxed);
+    }
+
+    /// Decrement the gauge atomically by `1`.
+    pub fn decr(&self) {
+        self.decr_n(1)
+    }
+
+    /// Set the value of the gauge atomically.
+    pub fn update(&self, val: i64) {
+        self.as_ref().store(val, Ordering::Relaxed)
+    }
+
+    /// Get the value of the gauge atomically.
+    pub fn value(&self) -> i64 {
+        self.as_ref().load(Ordering::Relaxed)
+    }
+}
+
+impl self::private::Sealed for Gauge {}
+unsafe impl SingleMetric for Gauge {
+    fn new(name: &CStr, desc: &CStr) -> Self {
+        Self(metric {
+            name: name.as_ptr() as *mut i8,
+            desc: desc.as_ptr() as *mut i8,
+            type_: METRIC_GAUGE,
+            data: metric_anon_union::gauge(0),
+        })
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.desc) }
+    }
+}
+
+impl fmt::Debug for Gauge {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Counter")
+            .field("name", unsafe { &CStr::from_ptr(self.0.name as *const i8) })
+            .field("desc", unsafe { &CStr::from_ptr(self.0.desc as *const i8) })
+            .field("counter", &self.value())
+            .finish()
+    }
+}
+
+impl AddAssign<i64> for Gauge {
+    fn add_assign(&mut self, val: i64) {
+        self.incr_n(val);
+    }
+}
+
+impl SubAssign<i64> for Gauge {
+    fn sub_assign(&mut self, val: i64) {
+        self.decr_n(val);
+    }
+}
+
+/// Impls of Metrics for cc_bindings types
+mod impls {
+    use cc_binding::*;
+    use super::Metrics;
+
+    macro_rules! c_str {
+        ($s:expr) => {
+            concat!($s, "\0").as_bytes().as_ptr() as *const i8 as *mut _
+        };
+    }
+
+    macro_rules! initialize_metric_value {
+        (METRIC_GAUGE) => {
+            metric_anon_union::gauge(0)
+        };
+        (METRIC_COUNTER) => {
+            metric_anon_union::counter(0)
+        };
+        (METRIC_FPN) => {
+            metric_anon_union::fpn(0.0)
+        };
+    }
+
+    macro_rules! impl_metrics {
+        {
+            $(
+                impl Metrics for $metrics_ty:ty {
+                    $(
+                        ACTION( $field:ident, $type:ident, $desc:expr )
+                    )*
+                }
+            )*
+        } => {
+            $(
+                unsafe impl Metrics for $metrics_ty {
+                    fn new() -> Self {
+                        Self {
+                            $(
+                                $field: metric {
+                                    name: c_str!($desc),
+                                    type_: $type,
+                                    desc: c_str!($desc),
+                                    data: initialize_metric_value!($type)
+                                },
+                            )*
+                        }
+                    }
+                }
+            )*
+        }
+    }
+
+    impl_metrics! {
+        impl Metrics for buf_metrics_st {
+            ACTION( buf_curr,         METRIC_GAUGE,   "# buf allocated"                        )
+            ACTION( buf_active,       METRIC_GAUGE,   "# buf in use/borrowed"                  )
+            ACTION( buf_create,       METRIC_COUNTER, "# buf creates"                          )
+            ACTION( buf_create_ex,    METRIC_COUNTER, "# buf create exceptions"                )
+            ACTION( buf_destroy,      METRIC_COUNTER, "# buf destroys"                         )
+            ACTION( buf_borrow,       METRIC_COUNTER, "# buf borrows"                          )
+            ACTION( buf_borrow_ex,    METRIC_COUNTER, "# buf borrow exceptions"                )
+            ACTION( buf_return,       METRIC_COUNTER, "# buf returns"                          )
+            ACTION( buf_memory,       METRIC_GAUGE,   "memory alloc'd to buf including header" )
+        }
+
+        impl Metrics for dbuf_metrics_st {
+            ACTION( dbuf_double,    METRIC_COUNTER, "# double completed"   )
+            ACTION( dbuf_double_ex, METRIC_COUNTER, "# double failed"      )
+            ACTION( dbuf_shrink,    METRIC_COUNTER, "# shrink completed"   )
+            ACTION( dbuf_shrink_ex, METRIC_COUNTER, "# shrink failed"      )
+            ACTION( dbuf_fit,       METRIC_COUNTER, "# fit completed"      )
+            ACTION( dbuf_fit_ex,    METRIC_COUNTER, "# fit failed"         )
+        }
+
+        impl Metrics for pipe_metrics_st {
+            ACTION( pipe_conn_create,    METRIC_COUNTER, "# pipe connections created"    )
+            ACTION( pipe_conn_create_ex, METRIC_COUNTER, "# pipe conn create exceptions" )
+            ACTION( pipe_conn_destroy,   METRIC_COUNTER, "# pipe connections destroyed"  )
+            ACTION( pipe_conn_curr ,     METRIC_GAUGE,   "# pipe conn allocated"         )
+            ACTION( pipe_conn_borrow,    METRIC_COUNTER, "# pipe connections borrowed"   )
+            ACTION( pipe_conn_borrow_ex, METRIC_COUNTER, "# pipe conn borrow exceptions" )
+            ACTION( pipe_conn_return,    METRIC_COUNTER, "# pipe connections returned"   )
+            ACTION( pipe_conn_active,    METRIC_GAUGE,   "# pipe conn being borrowed"    )
+            ACTION( pipe_open,           METRIC_COUNTER, "# pipe connects made"          )
+            ACTION( pipe_open_ex,        METRIC_COUNTER, "# pipe connect exceptions"     )
+            ACTION( pipe_close,          METRIC_COUNTER, "# pipe connection closed"      )
+            ACTION( pipe_recv,           METRIC_COUNTER, "# recv attempted"              )
+            ACTION( pipe_recv_ex,        METRIC_COUNTER, "# recv exceptions"             )
+            ACTION( pipe_recv_byte,      METRIC_COUNTER, "# bytes received"              )
+            ACTION( pipe_send,           METRIC_COUNTER, "# send attempted"              )
+            ACTION( pipe_send_ex,        METRIC_COUNTER, "# send exceptions"             )
+            ACTION( pipe_send_byte,      METRIC_COUNTER, "# bytes sent"                  )
+            ACTION( pipe_flag_ex,        METRIC_COUNTER, "# pipe flag exceptions"        )
+        }
+
+        impl Metrics for tcp_metrics_st {
+            ACTION( tcp_conn_create,    METRIC_COUNTER, "# tcp connections created"    )
+            ACTION( tcp_conn_create_ex, METRIC_COUNTER, "# tcp conn create exceptions" )
+            ACTION( tcp_conn_destroy,   METRIC_COUNTER, "# tcp connections destroyed"  )
+            ACTION( tcp_conn_curr,      METRIC_GAUGE,   "# tcp conn allocated"         )
+            ACTION( tcp_conn_borrow,    METRIC_COUNTER, "# tcp connections borrowed"   )
+            ACTION( tcp_conn_borrow_ex, METRIC_COUNTER, "# tcp conn borrow exceptions" )
+            ACTION( tcp_conn_return,    METRIC_COUNTER, "# tcp connections returned"   )
+            ACTION( tcp_conn_active,    METRIC_GAUGE,   "# tcp conn being borrowed"    )
+            ACTION( tcp_accept,         METRIC_COUNTER, "# tcp connection accepts"     )
+            ACTION( tcp_accept_ex,      METRIC_COUNTER, "# tcp accept exceptions"      )
+            ACTION( tcp_reject,         METRIC_COUNTER, "# tcp connection rejects"     )
+            ACTION( tcp_reject_ex,      METRIC_COUNTER, "# tcp reject exceptions"      )
+            ACTION( tcp_connect,        METRIC_COUNTER, "# tcp connects made"          )
+            ACTION( tcp_connect_ex,     METRIC_COUNTER, "# tcp connect exceptions "    )
+            ACTION( tcp_close,          METRIC_COUNTER, "# tcp connection closed"      )
+            ACTION( tcp_recv,           METRIC_COUNTER, "# recv attempted"             )
+            ACTION( tcp_recv_ex,        METRIC_COUNTER, "# recv exceptions"            )
+            ACTION( tcp_recv_byte,      METRIC_COUNTER, "# bytes received"             )
+            ACTION( tcp_send,           METRIC_COUNTER, "# send attempted"             )
+            ACTION( tcp_send_ex,        METRIC_COUNTER, "# send exceptions"            )
+            ACTION( tcp_send_byte,      METRIC_COUNTER, "# bytes sent"                 )
+        }
+
+        impl Metrics for sockio_metrics_st {
+            ACTION( buf_sock_create,    METRIC_COUNTER, "# buf sock created"           )
+            ACTION( buf_sock_create_ex, METRIC_COUNTER, "# buf sock create exceptions" )
+            ACTION( buf_sock_destroy,   METRIC_COUNTER, "# buf sock destroyed"         )
+            ACTION( buf_sock_curr,      METRIC_GAUGE,   "# buf sock allocated"         )
+            ACTION( buf_sock_borrow,    METRIC_COUNTER, "# buf sock borrowed"          )
+            ACTION( buf_sock_borrow_ex, METRIC_COUNTER, "# buf sock borrow exceptions" )
+            ACTION( buf_sock_return,    METRIC_COUNTER, "# buf sock returned"          )
+            ACTION( buf_sock_active,    METRIC_GAUGE,   "# buf sock being borrowed"    )
+        }
+
+        impl Metrics for timing_wheel_metrics_st {
+            ACTION( timeout_event_curr,     METRIC_GAUGE,   "# timeout events allocated"   )
+            ACTION( timeout_event_active,   METRIC_GAUGE,   "# timeout events in use"      )
+            ACTION( timeout_event_borrow,   METRIC_COUNTER, "# timeout events borrowed"    )
+            ACTION( timeout_event_borrow_ex,METRIC_COUNTER, "# tevents borrow errors"      )
+            ACTION( timeout_event_return,   METRIC_COUNTER, "# timeout events returned"    )
+            ACTION( timing_wheel_insert,    METRIC_COUNTER, "# tevent insertions"          )
+            ACTION( timing_wheel_remove,    METRIC_COUNTER, "# tevent removal"             )
+            ACTION( timing_wheel_event,     METRIC_GAUGE,   "# tevents in timing wheels"   )
+            ACTION( timing_wheel_process,   METRIC_COUNTER, "# tevents processed"          )
+            ACTION( timing_wheel_tick,      METRIC_COUNTER, "# ticks processed"            )
+            ACTION( timing_wheel_exec,      METRIC_COUNTER, "# timing wheel executions "   )
+        }
+
+        impl Metrics for event_metrics_st {
+            ACTION( event_total,        METRIC_COUNTER, "# events returned"    )
+            ACTION( event_loop,         METRIC_COUNTER, "# event loop returns" )
+            ACTION( event_read,         METRIC_COUNTER, "# reads registered"   )
+            ACTION( event_write,        METRIC_COUNTER, "# writes registered"  )
+        }
+
+        impl Metrics for log_metrics_st {
+            ACTION( log_create,     METRIC_COUNTER, "# loggers created"                )
+            ACTION( log_create_ex,  METRIC_COUNTER, "# log create errors"              )
+            ACTION( log_destroy,    METRIC_COUNTER, "# loggers destroyed"              )
+            ACTION( log_curr,       METRIC_GAUGE,   "current # loggers"                )
+            ACTION( log_open,       METRIC_COUNTER, "# files opened by loggers"        )
+            ACTION( log_open_ex,    METRIC_COUNTER, "# logger open file errors"        )
+            ACTION( log_write,      METRIC_COUNTER, "# log messages written"           )
+            ACTION( log_write_byte, METRIC_COUNTER, "# bytes written by log"           )
+            ACTION( log_write_ex,   METRIC_COUNTER, "# log write errors"               )
+            ACTION( log_skip,       METRIC_COUNTER, "# messages not completely logged" )
+            ACTION( log_skip_byte,  METRIC_COUNTER, "# bytes unable to be logged"      )
+            ACTION( log_flush,      METRIC_COUNTER, "# log flushes to disk"            )
+            ACTION( log_flush_ex,   METRIC_COUNTER, "# errors flushing to disk"        )
+        }
+
+        impl Metrics for rbuf_metrics_st {
+            ACTION( rbuf_create,    METRIC_COUNTER, "# rbuf created"         )
+            ACTION( rbuf_create_ex, METRIC_COUNTER, "# rbuf create errors"   )
+            ACTION( rbuf_destroy,   METRIC_COUNTER, "# rbuf destroyed"       )
+            ACTION( rbuf_curr,      METRIC_GAUGE,   "# rbuf allocated"       )
+            ACTION( rbuf_byte,      METRIC_GAUGE,   "# rbuf bytes allocated" )
+        }
+    }
+}
+
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    macro_rules! c_str {
+        ($s:expr) => {
+            unsafe { CStr::from_bytes_with_nul_unchecked(concat!($s, "\0").as_bytes()) }
+        };
+    }
+
+    #[test]
+    fn gauge_basic_use() {
+        let gauge = Gauge::new(c_str!("test"), c_str!("test desc"));
+
+        assert_eq!(gauge.value(), 0);
+        gauge.incr();
+        assert_eq!(gauge.value(), 1);
+        gauge.decr_n(10);
+        assert_eq!(gauge.value(), -9);
+    }
+
+    #[test]
+    fn counter_basic_use() {
+        let ctr = Counter::new(c_str!("test"), c_str!("test desc"));
+
+        assert_eq!(ctr.value(), 0);
+        ctr.incr();
+        assert_eq!(ctr.value(), 1);
+        ctr.incr_n(400);
+        assert_eq!(ctr.value(), 401);
+    }
+
+    #[test]
+    fn fpn_basic_use() {
+        let fpn = Fpn::new(c_str!("test"), c_str!("test desc"));
+
+        assert_eq!(fpn.value(), 0.0);
+        fpn.update(500.0);
+        assert_eq!(fpn.value(), 500.0);
+    }
+
+    #[test]
+    fn size_sanity_test() {
+        // Protect against a bad bindgen run
+        assert!(std::mem::size_of::<metric>() != 0);
+    }
+}

--- a/rust/ccommon_rs/src/metric/counter.rs
+++ b/rust/ccommon_rs/src/metric/counter.rs
@@ -1,0 +1,110 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fmt;
+use std::ops::{AddAssign, SubAssign};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use cc_binding::{metric, metric_anon_union, METRIC_COUNTER};
+
+use super::private::Sealed;
+use super::SingleMetric;
+
+/// An atomic counter metric.
+///
+/// Exposes `incr` and `decr` operations that can also be
+/// used via operators `+=` and `-=`.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Counter(metric);
+
+impl Counter {
+    fn as_ref(&self) -> &AtomicU64 {
+        unsafe { &*self.0.data.as_ptr::<AtomicU64>() }
+    }
+
+    /// Increment the counter by `n` atomically.
+    pub fn incr_n(&self, n: u64) {
+        self.as_ref().fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Increment the counter by `1` atomically.
+    pub fn incr(&self) {
+        self.incr_n(1)
+    }
+
+    /// Decrement the counter by `n` atomically.
+    pub fn decr_n(&self, n: u64) {
+        self.as_ref().fetch_sub(n, Ordering::Relaxed);
+    }
+
+    /// Decrement the counter by `1` atomically.
+    pub fn decr(&self) {
+        self.decr_n(1)
+    }
+
+    /// Atomically store a value in the counter.
+    pub fn update(&self, val: u64) {
+        self.as_ref().store(val, Ordering::Relaxed)
+    }
+
+    /// Atomically get the value out of the counter.
+    pub fn value(&self) -> u64 {
+        self.as_ref().load(Ordering::Relaxed)
+    }
+}
+
+impl Sealed for Counter {}
+
+unsafe impl SingleMetric for Counter {
+    fn new(name: &CStr, desc: &CStr) -> Self {
+        Self(metric {
+            name: name.as_ptr() as *mut i8,
+            desc: desc.as_ptr() as *mut i8,
+            type_: METRIC_COUNTER,
+            data: metric_anon_union::counter(0),
+        })
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.desc) }
+    }
+}
+
+impl fmt::Debug for Counter {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Counter")
+            .field("name", unsafe { &CStr::from_ptr(self.0.name as *const i8) })
+            .field("desc", unsafe { &CStr::from_ptr(self.0.desc as *const i8) })
+            .field("counter", &self.value())
+            .finish()
+    }
+}
+
+impl AddAssign<u64> for Counter {
+    fn add_assign(&mut self, val: u64) {
+        self.incr_n(val);
+    }
+}
+
+impl SubAssign<u64> for Counter {
+    fn sub_assign(&mut self, val: u64) {
+        self.decr_n(val);
+    }
+}

--- a/rust/ccommon_rs/src/metric/fpn.rs
+++ b/rust/ccommon_rs/src/metric/fpn.rs
@@ -30,14 +30,12 @@ pub struct Fpn(metric);
 impl Fpn {
     /// Get the value atomically.
     pub fn value(&self) -> f64 {
-        unsafe { std::mem::transmute((*self.0.data.as_ptr::<AtomicU64>()).load(Ordering::Relaxed)) }
+        f64::from_bits(unsafe { (*self.0.data.as_ptr::<AtomicU64>()).load(Ordering::Relaxed) })
     }
 
     /// Update the value atomically.
     pub fn update(&self, val: f64) {
-        unsafe {
-            (*self.0.data.as_ptr::<AtomicU64>()).store(std::mem::transmute(val), Ordering::Relaxed)
-        }
+        unsafe { (*self.0.data.as_ptr::<AtomicU64>()).store(val.to_bits(), Ordering::Relaxed) }
     }
 }
 

--- a/rust/ccommon_rs/src/metric/fpn.rs
+++ b/rust/ccommon_rs/src/metric/fpn.rs
@@ -1,0 +1,72 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use cc_binding::{metric, metric_anon_union, METRIC_FPN};
+
+use super::private::Sealed;
+use super::SingleMetric;
+
+/// A `f64` metric that can be updated atomically.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Fpn(metric);
+
+impl Fpn {
+    /// Get the value atomically.
+    pub fn value(&self) -> f64 {
+        unsafe { std::mem::transmute((*self.0.data.as_ptr::<AtomicU64>()).load(Ordering::Relaxed)) }
+    }
+
+    /// Update the value atomically.
+    pub fn update(&self, val: f64) {
+        unsafe {
+            (*self.0.data.as_ptr::<AtomicU64>()).store(std::mem::transmute(val), Ordering::Relaxed)
+        }
+    }
+}
+
+impl Sealed for Fpn {}
+
+unsafe impl SingleMetric for Fpn {
+    fn new(name: &CStr, desc: &CStr) -> Self {
+        Self(metric {
+            name: name.as_ptr() as *mut i8,
+            desc: desc.as_ptr() as *mut i8,
+            type_: METRIC_FPN,
+            data: metric_anon_union::gauge(0),
+        })
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.desc) }
+    }
+}
+
+impl fmt::Debug for Fpn {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Fpn")
+            .field("name", unsafe { &CStr::from_ptr(self.0.name as *const i8) })
+            .field("desc", unsafe { &CStr::from_ptr(self.0.desc as *const i8) })
+            .field("fpn", &self.value())
+            .finish()
+    }
+}

--- a/rust/ccommon_rs/src/metric/gauge.rs
+++ b/rust/ccommon_rs/src/metric/gauge.rs
@@ -1,0 +1,109 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fmt;
+use std::ops::{AddAssign, SubAssign};
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use cc_binding::{metric, metric_anon_union, METRIC_GAUGE};
+
+use super::private::Sealed;
+use super::SingleMetric;
+
+/// A gauge metric that can be updated atomically.
+///
+/// Exposes `incr`, `decr`, and `update`. `incr` and `decr`
+/// can be used through operators `+=` and `-=`.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Gauge(metric);
+
+impl Gauge {
+    fn as_ref(&self) -> &AtomicI64 {
+        unsafe { &*self.0.data.as_ptr::<AtomicI64>() }
+    }
+
+    /// Increment the gauge atomically by `n`.
+    pub fn incr_n(&self, n: i64) {
+        self.as_ref().fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Increment the gauge atomically by `1`.
+    pub fn incr(&self) {
+        self.incr_n(1)
+    }
+
+    /// Decrement the gauge atomically by `n`.
+    pub fn decr_n(&self, n: i64) {
+        self.as_ref().fetch_sub(n, Ordering::Relaxed);
+    }
+
+    /// Decrement the gauge atomically by `1`.
+    pub fn decr(&self) {
+        self.decr_n(1)
+    }
+
+    /// Set the value of the gauge atomically.
+    pub fn update(&self, val: i64) {
+        self.as_ref().store(val, Ordering::Relaxed)
+    }
+
+    /// Get the value of the gauge atomically.
+    pub fn value(&self) -> i64 {
+        self.as_ref().load(Ordering::Relaxed)
+    }
+}
+
+impl Sealed for Gauge {}
+unsafe impl SingleMetric for Gauge {
+    fn new(name: &CStr, desc: &CStr) -> Self {
+        Self(metric {
+            name: name.as_ptr() as *mut i8,
+            desc: desc.as_ptr() as *mut i8,
+            type_: METRIC_GAUGE,
+            data: metric_anon_union::gauge(0),
+        })
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.desc) }
+    }
+}
+
+impl fmt::Debug for Gauge {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Counter")
+            .field("name", unsafe { &CStr::from_ptr(self.0.name as *const i8) })
+            .field("desc", unsafe { &CStr::from_ptr(self.0.desc as *const i8) })
+            .field("counter", &self.value())
+            .finish()
+    }
+}
+
+impl AddAssign<i64> for Gauge {
+    fn add_assign(&mut self, val: i64) {
+        self.incr_n(val);
+    }
+}
+
+impl SubAssign<i64> for Gauge {
+    fn sub_assign(&mut self, val: i64) {
+        self.decr_n(val);
+    }
+}

--- a/rust/ccommon_rs/src/option.rs
+++ b/rust/ccommon_rs/src/option.rs
@@ -1,0 +1,577 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types and methods for dealing with ccommon options.
+
+use std::ffi::CStr;
+use std::fmt;
+
+use cc_binding::{
+    option, option_describe_all, option_free, option_load_default, option_load_file,
+    option_print_all, option_val_u, OPTION_TYPE_BOOL, OPTION_TYPE_FPN, OPTION_TYPE_STR,
+    OPTION_TYPE_UINT,
+};
+
+// Sealed trait to prevent SingleOption from ever being implemented
+// from outside of this crate.
+mod private {
+    pub trait Sealed {}
+}
+
+use self::private::Sealed;
+
+/// A single option.
+///
+/// This trait is sealed and cannot be implemented outside
+/// of ccommon_rs.
+pub unsafe trait SingleOption: self::private::Sealed {
+    /// The type of the value contained within this option.
+    type Value;
+
+    /// Create an option with the given description, name,
+    /// and default value.
+    ///
+    /// Normally, this should only be called by the derive
+    /// macro for `Options`.
+    fn new(default: Self::Value, name: &'static CStr, desc: &'static CStr) -> Self;
+
+    /// Create an option with the given description, name,
+    /// and `Default::default()` as the default value.
+    ///
+    /// The only exception is that [`Str`](crate::option::Str)
+    /// uses `std::ptr::null_mut()` as it's default value since
+    /// pointers do not implement `Default`.
+    ///
+    /// Normally, this should only be called by the derive macro
+    /// for `Options`.
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self;
+
+    /// The name of this option
+    fn name(&self) -> &'static CStr;
+    /// A C string describing this option
+    fn desc(&self) -> &'static CStr;
+    /// The current value of this option
+    fn value(&self) -> Self::Value;
+    /// The default value for this option
+    fn default(&self) -> Self::Value;
+    /// Whether the option has been set externally
+    fn is_set(&self) -> bool;
+
+    /// Overwrite the current value for the option.
+    ///
+    /// This will always set `is_set` to true.
+    fn set_value(&mut self, val: Self::Value);
+}
+
+/// A type that can be safely viewed as a contiguous
+/// array of [`option`s][0].
+///
+/// See [`OptionsExt`] for more useful functions on
+/// `Options`.
+///
+/// This trait should normally only be implemented through
+/// `#[derive(Options)]`. However, it must be implemented
+/// manually for C types which have been bound using bindgen.
+///
+/// [0]: ../../cc_binding/struct.option.html
+pub unsafe trait Options: Sized {
+    fn new() -> Self;
+}
+
+pub trait OptionExt: Options {
+    /// The number of options in this object when it
+    /// is interpreted as an array.
+    ///
+    /// # Panics
+    /// Panics if the size of this type is not a multiple
+    /// of thie size of `option`.
+    fn num_options() -> usize {
+        use std::mem::size_of;
+
+        // If this assert fails then there was no way that
+        // options upholds it's safety requirements so it's
+        // better to fail here.
+        assert!(size_of::<Self>() % size_of::<option>() == 0);
+
+        // If this assert fails then we'll pass an invalid
+        // size to several ccommon methods.
+        assert!(size_of::<Self>() / size_of::<option>() < std::u32::MAX as usize);
+
+        size_of::<Self>() / size_of::<option>()
+    }
+
+    /// Get `self` as a const pointer to an array of `option`s.
+    ///
+    /// # Panics
+    /// Panics if the size of this type is not a multiple
+    /// of thie size of `option`.
+    fn as_ptr(&self) -> *const option {
+        self as *const _ as *const option
+    }
+
+    /// Get `self` as a mutable pointer to an array of `option`s.
+    ///
+    /// # Panics
+    /// Panics if the size of this type is not a multiple
+    /// of thie size of `option`.
+    fn as_mut_ptr(&mut self) -> *mut option {
+        self as *mut _ as *mut option
+    }
+
+    /// Print a description of all options in the current object
+    /// given using the default value, name, and description.
+    ///
+    /// Internally this calls out to `option_describe_all`.
+    fn describe_all(&self) {
+        unsafe {
+            option_describe_all(
+                // Note: ccommon uses a mutable pointer but it
+                //       should really be a const pointer.
+                self.as_ptr() as *mut _,
+                Self::num_options() as u32,
+            )
+        }
+    }
+
+    /// Print out the values of all options.
+    ///
+    /// Internally this calls out to `option_print_all`.
+    fn print_all(&self) {
+        unsafe {
+            option_print_all(
+                // Note: ccommon uses a mutable pointer but it
+                //       should really be a const pointer.
+                self.as_ptr() as *mut _,
+                Self::num_options() as u32,
+            )
+        }
+    }
+
+    /// Load default values for all options.
+    ///
+    /// Internally this calls `option_load_default`
+    fn load_default(&mut self) -> Result<(), crate::Error> {
+        let status = unsafe { option_load_default(self.as_mut_ptr(), Self::num_options() as u32) };
+
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(status.into())
+        }
+    }
+
+    /// Load options from a file in `.ini` format.
+    ///
+    /// Internally this calls `option_load_file`.
+    fn load_from_libc_file(&mut self, file: *mut libc::FILE) -> Result<(), crate::Error> {
+        let status =
+            unsafe { option_load_file(file, self.as_mut_ptr(), Self::num_options() as u32) };
+
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(status.into())
+        }
+    }
+}
+
+impl<T: Options> OptionExt for T {}
+
+/// A boolean option.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Bool(option);
+
+impl Sealed for Bool {}
+
+unsafe impl SingleOption for Bool {
+    type Value = bool;
+
+    fn new(default: bool, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_BOOL,
+            default_val: option_val_u { vbool: default },
+            val: option_val_u { vbool: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(Default::default(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vbool }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vbool }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vbool: val }
+    }
+}
+
+impl fmt::Debug for Bool {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Bool")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}
+
+/// An unsigned integer option.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct UInt(option);
+
+impl Sealed for UInt {}
+
+unsafe impl SingleOption for UInt {
+    type Value = cc_binding::uintmax_t;
+
+    fn new(default: Self::Value, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_UINT,
+            default_val: option_val_u { vuint: default },
+            val: option_val_u { vuint: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(Default::default(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vuint }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vuint }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vuint: val }
+    }
+}
+
+impl fmt::Debug for UInt {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("UInt")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}
+
+/// A floating-point option.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Float(option);
+
+impl Sealed for Float {}
+
+unsafe impl SingleOption for Float {
+    type Value = f64;
+
+    fn new(default: Self::Value, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_FPN,
+            default_val: option_val_u { vfpn: default },
+            val: option_val_u { vfpn: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(Default::default(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vfpn }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vfpn }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vfpn: val }
+    }
+}
+
+impl fmt::Debug for Float {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Float")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}
+
+/// A string option.
+///
+/// Note that this type wraps a C string.
+#[repr(transparent)]
+pub struct Str(option);
+
+impl Sealed for Str {}
+
+unsafe impl SingleOption for Str {
+    type Value = *mut std::os::raw::c_char;
+
+    fn new(default: Self::Value, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_STR,
+            default_val: option_val_u { vstr: default },
+            val: option_val_u { vstr: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(std::ptr::null_mut(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vstr }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vstr }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vstr: val }
+    }
+}
+
+// TODO(sean): Debug print the string pointer
+impl fmt::Debug for Str {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Str")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}
+
+impl Drop for Str {
+    fn drop(&mut self) {
+        unsafe { option_free(self as *mut _ as *mut option, 1) }
+    }
+}
+
+/// Implementations of Options for cc_bindings types
+mod impls {
+    use cc_binding::*;
+    use super::Options;
+
+    macro_rules! c_str {
+        ($s:expr) => {
+            concat!($s, "\0").as_bytes().as_ptr() as *const i8 as *mut _
+        };
+    }
+
+    macro_rules! initialize_option_value {
+        (OPTION_TYPE_BOOL, $default:expr) => {
+            option_val_u { vbool: $default }
+        };
+        (OPTION_TYPE_UINT, $default:expr) => {
+            option_val_u { vuint: $default.into() }
+        };
+        (OPTION_TYPE_FPN, $default:expr) => {
+            option_val_u { vfpn: $default }
+        };
+        (OPTION_TYPE_STR, $default:expr) => {
+            option_val_u { vstr: $default }
+        };
+    }
+
+    macro_rules! impl_options {
+        {
+            $(
+                impl Options for $metrics_ty:ty {
+                    $(
+                        ACTION( $field:ident, $type:ident, $default:expr, $desc:expr )
+                    )*
+                }
+            )*
+        } => {
+            $(
+                unsafe impl Options for $metrics_ty {
+                    fn new() -> Self {
+                        Self {
+                            $(
+                                $field: option {
+                                    name: c_str!($desc),
+                                    set: false,
+                                    type_: $type,
+                                    default_val: initialize_option_value!($type, $default),
+                                    val: initialize_option_value!($type, $default),
+                                    description: c_str!($desc)
+                                },
+                            )*
+                        }
+                    }
+                }
+            )*
+        }
+    }
+
+    impl_options! {
+        impl Options for buf_options_st {
+            ACTION( buf_init_size,  OPTION_TYPE_UINT,   BUF_DEFAULT_SIZE,   "init buf size incl header" )
+            ACTION( buf_poolsize,   OPTION_TYPE_UINT,   BUF_POOLSIZE,       "buf pool size"             )
+        }
+
+        impl Options for dbuf_options_st {
+            ACTION( dbuf_max_power,      OPTION_TYPE_UINT,  DBUF_DEFAULT_MAX,   "max number of doubles")
+        }
+
+        impl Options for pipe_options_st {
+            ACTION( pipe_poolsize,      OPTION_TYPE_UINT,   PIPE_POOLSIZE,  "pipe conn pool size" )
+        }
+
+        impl Options for tcp_options_st {
+            ACTION( tcp_backlog,    OPTION_TYPE_UINT,   TCP_BACKLOG,    "tcp conn backlog limit" )
+            ACTION( tcp_poolsize,   OPTION_TYPE_UINT,   TCP_POOLSIZE,   "tcp conn pool size"     )
+        }
+
+        impl Options for sockio_options_st {
+            ACTION( buf_sock_poolsize,  OPTION_TYPE_UINT,   BUFSOCK_POOLSIZE,   "buf_sock limit" )
+        }
+
+        impl Options for array_options_st {
+            ACTION( array_nelem_delta,  OPTION_TYPE_UINT,   NELEM_DELTA,      "max nelem delta during expansion" )
+        }
+
+        impl Options for debug_options_st {
+            ACTION( debug_log_level, OPTION_TYPE_UINT, DEBUG_LOG_LEVEL,  "debug log level"     )
+            ACTION( debug_log_file,  OPTION_TYPE_STR,  DEBUG_LOG_FILE,   "debug log file"      )
+            ACTION( debug_log_nbuf,  OPTION_TYPE_UINT, DEBUG_LOG_NBUF,   "debug log buf size"  )
+        }
+
+        impl Options for stats_log_options_st {
+            ACTION( stats_log_file, OPTION_TYPE_STR,  std::ptr::null_mut(), "file storing stats"   )
+            ACTION( stats_log_nbuf, OPTION_TYPE_UINT, STATS_LOG_NBUF,       "stats log buf size"   )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::Options;
+
+    #[derive(Options)]
+    #[repr(C)]
+    struct TestOptions {
+        #[desc = "The first test option"]
+        opt1: Bool,
+
+        #[desc = "The second test option"]
+        #[default(5)]
+        opt2: UInt,
+
+        #[desc = "The third test option"]
+        #[default(35.0)]
+        opt3: Float,
+    }
+
+    #[test]
+    fn test_option_properties() {
+        assert_eq!(TestOptions::num_options(), 3);
+    }
+
+    #[test]
+    fn test_option_defaults() {
+        let options = TestOptions::new();
+        let ptr =
+            unsafe { std::slice::from_raw_parts(options.as_ptr(), TestOptions::num_options()) };
+
+        unsafe {
+            assert_eq!(ptr[0].default_val.vbool, false);
+            assert_eq!(ptr[0].set, false);
+
+            assert_eq!(ptr[1].default_val.vuint, 5);
+            assert_eq!(ptr[1].set, false);
+
+            assert_eq!(ptr[2].default_val.vfpn, 35.0);
+            assert_eq!(ptr[2].set, false);
+        }
+    }
+
+    #[test]
+    fn option_size_sanity() {
+        // Protect against a bad bindgen run
+        assert!(std::mem::size_of::<option>() != 0);
+    }
+}

--- a/rust/ccommon_rs/src/option/boolean.rs
+++ b/rust/ccommon_rs/src/option/boolean.rs
@@ -1,0 +1,79 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fmt;
+
+use cc_binding::{option, option_val_u, OPTION_TYPE_BOOL};
+
+use super::{Sealed, SingleOption};
+
+/// A boolean option.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Bool(option);
+
+impl Sealed for Bool {}
+
+unsafe impl SingleOption for Bool {
+    type Value = bool;
+
+    fn new(default: bool, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_BOOL,
+            default_val: option_val_u { vbool: default },
+            val: option_val_u { vbool: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(Default::default(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vbool }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vbool }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vbool: val }
+    }
+}
+
+impl fmt::Debug for Bool {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Bool")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}

--- a/rust/ccommon_rs/src/option/fpn.rs
+++ b/rust/ccommon_rs/src/option/fpn.rs
@@ -1,0 +1,79 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fmt;
+
+use cc_binding::{option, option_val_u, OPTION_TYPE_FPN};
+
+use super::{Sealed, SingleOption};
+
+/// A floating-point option.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Float(option);
+
+impl Sealed for Float {}
+
+unsafe impl SingleOption for Float {
+    type Value = f64;
+
+    fn new(default: Self::Value, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_FPN,
+            default_val: option_val_u { vfpn: default },
+            val: option_val_u { vfpn: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(Default::default(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vfpn }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vfpn }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vfpn: val }
+    }
+}
+
+impl fmt::Debug for Float {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Float")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}

--- a/rust/ccommon_rs/src/option/mod.rs
+++ b/rust/ccommon_rs/src/option/mod.rs
@@ -295,6 +295,8 @@ mod impls {
     }
 }
 
+use crate::Options;
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -303,15 +305,13 @@ mod test {
     #[derive(Options)]
     #[repr(C)]
     struct TestOptions {
-        #[desc = "The first test option"]
+        #[option(desc = "The first test option")]
         opt1: Bool,
 
-        #[desc = "The second test option"]
-        #[default(5)]
+        #[option(desc = "The second test option", default = 5)]
         opt2: UInt,
 
-        #[desc = "The third test option"]
-        #[default(35.0)]
+        #[option(desc = "The third test option", default = 35.0)]
         opt3: Float,
     }
 

--- a/rust/ccommon_rs/src/option/string.rs
+++ b/rust/ccommon_rs/src/option/string.rs
@@ -1,0 +1,87 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fmt;
+
+use cc_binding::{option, option_free, option_val_u, OPTION_TYPE_STR};
+
+use super::{Sealed, SingleOption};
+
+/// A string option.
+///
+/// Note that this type wraps a C string.
+#[repr(transparent)]
+pub struct Str(option);
+
+impl Sealed for Str {}
+
+unsafe impl SingleOption for Str {
+    type Value = *mut std::os::raw::c_char;
+
+    fn new(default: Self::Value, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_STR,
+            default_val: option_val_u { vstr: default },
+            val: option_val_u { vstr: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(std::ptr::null_mut(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vstr }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vstr }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vstr: val }
+    }
+}
+
+// TODO(sean): Debug print the string pointer
+impl fmt::Debug for Str {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Str")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}
+
+impl Drop for Str {
+    fn drop(&mut self) {
+        unsafe { option_free(self as *mut _ as *mut option, 1) }
+    }
+}

--- a/rust/ccommon_rs/src/option/uint.rs
+++ b/rust/ccommon_rs/src/option/uint.rs
@@ -1,0 +1,79 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fmt;
+
+use cc_binding::{option, option_val_u, OPTION_TYPE_UINT};
+
+use super::{Sealed, SingleOption};
+
+/// An unsigned integer option.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct UInt(option);
+
+impl Sealed for UInt {}
+
+unsafe impl SingleOption for UInt {
+    type Value = cc_binding::uintmax_t;
+
+    fn new(default: Self::Value, name: &'static CStr, desc: &'static CStr) -> Self {
+        Self(option {
+            name: name.as_ptr() as *mut _,
+            set: false,
+            type_: OPTION_TYPE_UINT,
+            default_val: option_val_u { vuint: default },
+            val: option_val_u { vuint: default },
+            description: desc.as_ptr() as *mut _,
+        })
+    }
+    fn defaulted(name: &'static CStr, desc: &'static CStr) -> Self {
+        Self::new(Default::default(), name, desc)
+    }
+
+    fn name(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.name) }
+    }
+    fn desc(&self) -> &'static CStr {
+        unsafe { CStr::from_ptr(self.0.description) }
+    }
+    fn value(&self) -> Self::Value {
+        unsafe { self.0.val.vuint }
+    }
+    fn default(&self) -> Self::Value {
+        unsafe { self.0.default_val.vuint }
+    }
+    fn is_set(&self) -> bool {
+        self.0.set
+    }
+
+    fn set_value(&mut self, val: Self::Value) {
+        self.0.set = true;
+        self.0.val = option_val_u { vuint: val }
+    }
+}
+
+impl fmt::Debug for UInt {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("UInt")
+            .field("name", &self.name())
+            .field("desc", &self.desc())
+            .field("value", &self.value())
+            .field("default", &self.default())
+            .field("is_set", &self.is_set())
+            .finish()
+    }
+}

--- a/rust/ccommon_rs/src/util.rs
+++ b/rust/ccommon_rs/src/util.rs
@@ -17,8 +17,6 @@ use std::ffi::CStr;
 use std::fs;
 use std::os::raw::c_char;
 
-use cc_binding::{metric, option};
-
 /// Recursively removes files and directories under `path` before removing `path` itself.
 /// Returns 0 on success and -1 on error. `errno` will be set to the cause of the failure.
 #[no_mangle]
@@ -39,68 +37,5 @@ pub unsafe extern "C" fn cc_util_rm_rf_rs(path: *const c_char) -> i32 {
             eprintln!("ERROR, cc_util_rm_rf_rs {:#?}", err);
             -1
         }
-    }
-}
-
-pub unsafe trait AsMetricArray {
-    unsafe fn as_metric_array<'a>(&'a self) -> &'a [metric] {
-        use std::mem::{size_of, size_of_val};
-        use std::slice;
-
-        // Panic in cases that obviously won't work
-        assert_eq!(size_of_val(self) % size_of::<metric>(), 0);
-
-        let count = size_of_val(self) / size_of::<metric>();
-        slice::from_raw_parts(self as *const _ as *const metric, count)
-    }
-    unsafe fn as_metric_array_mut<'a>(&'a mut self) -> &'a mut [metric] {
-        use std::mem::{size_of, size_of_val};
-        use std::slice;
-
-        // Panic in cases that obviously won't work
-        assert_eq!(size_of_val(self) % size_of::<metric>(), 0);
-
-        let count = size_of_val(self) / size_of::<metric>();
-        slice::from_raw_parts_mut(self as *mut _ as *mut metric, count)
-    }
-
-    unsafe fn describe_all(&self) {
-        let slice = self.as_metric_array();
-
-        use cc_binding::metric_describe_all;
-        metric_describe_all(slice.as_ptr() as *mut _, slice.len() as u32)
-    }
-}
-
-pub unsafe trait AsOptionArray {
-    unsafe fn as_option_array<'a>(&'a self) -> &'a [option] {
-        use std::mem::{size_of, size_of_val};
-        use std::slice;
-
-        // Panic in cases that obviously won't work
-        assert_eq!(size_of_val(self) % size_of::<option>(), 0);
-
-        let count = size_of_val(self) / size_of::<option>();
-
-        slice::from_raw_parts(self as *const _ as *const option, count)
-    }
-    unsafe fn as_option_array_mut<'a>(&'a mut self) -> &'a mut [option] {
-        use std::mem::{size_of, size_of_val};
-        use std::slice;
-
-        // Panic in cases that obviously won't work
-        assert_eq!(size_of_val(self) % size_of::<option>(), 0);
-
-        let count = size_of_val(self) / size_of::<option>();
-
-        slice::from_raw_parts_mut(self as *mut _ as *mut option, count)
-    }
-
-    unsafe fn describe_all(&self) {
-        use cc_binding::option_describe_all;
-
-        let slice = self.as_option_array();
-
-        option_describe_all(slice.as_ptr() as *mut _, slice.len() as u32)
     }
 }

--- a/rust/ccommon_rs/src/util.rs
+++ b/rust/ccommon_rs/src/util.rs
@@ -81,7 +81,7 @@ pub unsafe trait AsOptionArray {
         assert_eq!(size_of_val(self) % size_of::<option>(), 0);
 
         let count = size_of_val(self) / size_of::<option>();
-        
+
         slice::from_raw_parts(self as *const _ as *const option, count)
     }
     unsafe fn as_option_array_mut<'a>(&'a mut self) -> &'a mut [option] {
@@ -92,7 +92,7 @@ pub unsafe trait AsOptionArray {
         assert_eq!(size_of_val(self) % size_of::<option>(), 0);
 
         let count = size_of_val(self) / size_of::<option>();
-        
+
         slice::from_raw_parts_mut(self as *mut _ as *mut option, count)
     }
 

--- a/rust/ccommon_rs/tests/derive_metrics.rs
+++ b/rust/ccommon_rs/tests/derive_metrics.rs
@@ -6,12 +6,11 @@ use ccommon_rs::Metrics;
 #[derive(Metrics)]
 #[repr(C)]
 pub struct TestMetrics {
-    #[desc = "A test gauge metric"]
+    #[metric(desc = "A test gauge metric")]
     pub m1: Gauge,
-    #[desc = "A test counter metric"]
+    #[metric(desc = "A test counter metric")]
     pub m2: Counter,
-    #[desc = "A test fpn metric"]
-    #[name = "test.other.m3"]
+    #[metric(desc = "A test fpn metric", name = "test.other.m3")]
     pub m3: Fpn,
 }
 
@@ -19,8 +18,7 @@ pub struct TestMetrics {
 #[repr(C)]
 pub struct Nested {
     pub inner: TestMetrics,
-    #[desc = "Another test metric"]
-    #[name = "nested.other"]
+    #[metric(desc = "Another test metric", name = "nested.other")]
     other: Gauge,
 }
 

--- a/rust/ccommon_rs/tests/derive_metrics.rs
+++ b/rust/ccommon_rs/tests/derive_metrics.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "derive")]
+
+use ccommon_rs::metric::*;
+use ccommon_rs::Metrics;
+
+#[derive(Metrics)]
+#[repr(C)]
+pub struct TestMetrics {
+    #[desc = "A test gauge metric"]
+    pub m1: Gauge,
+    #[desc = "A test counter metric"]
+    pub m2: Counter,
+    #[desc = "A test fpn metric"]
+    #[name = "test.other.m3"]
+    pub m3: Fpn,
+}
+
+#[derive(Metrics)]
+#[repr(C)]
+pub struct Nested {
+    pub inner: TestMetrics,
+    #[desc = "Another test metric"]
+    #[name = "nested.other"]
+    other: Gauge,
+}
+
+#[derive(Metrics)]
+#[repr(transparent)]
+pub struct Tuple(Nested);
+
+#[derive(Metrics)]
+#[repr(C, align(16))]
+pub struct Marker;
+
+macro_rules! c_str {
+    ($s:expr) => {
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(concat!($s, "\0").as_bytes()) }
+    };
+}
+
+#[test]
+fn this_compiles() {
+    let nested = Nested::new();
+
+    assert_eq!(nested.other.name(), c_str!("nested.other"));
+    assert_eq!(nested.inner.m3.name(), c_str!("test.other.m3"));
+    assert_eq!(nested.inner.m2.name(), c_str!("m2"));
+}

--- a/rust/ccommon_rs/tests/derive_options.rs
+++ b/rust/ccommon_rs/tests/derive_options.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "derive")]
+
+use ccommon_rs::option::*;
+use ccommon_rs::Options;
+
+#[derive(Options)]
+#[repr(C)]
+pub struct TestMetrics {
+    #[desc = "A test gauge metric"]
+    pub m1: Float,
+    #[desc = "A test counter metric"]
+    pub m2: Bool,
+    #[desc = "A test fpn metric"]
+    #[name = "test.other.m3"]
+    pub m3: UInt,
+}
+
+#[derive(Options)]
+#[repr(C)]
+pub struct Nested {
+    pub inner: TestMetrics,
+    #[desc = "Another test metric"]
+    #[name = "nested.other"]
+    #[default(std::ptr::null_mut())]
+    other: Str,
+    #[desc = "Defaulted str"]
+    defaulted: Str,
+}
+
+#[derive(Options)]
+#[repr(transparent)]
+pub struct Tuple(Nested);
+
+#[derive(Options)]
+#[repr(C, align(16))]
+pub struct Marker;
+
+macro_rules! c_str {
+    ($s:expr) => {
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(concat!($s, "\0").as_bytes()) }
+    };
+}
+
+#[test]
+fn this_compiles() {
+    let nested = Nested::new();
+
+    assert_eq!(nested.other.name(), c_str!("nested.other"));
+    assert_eq!(nested.inner.m3.name(), c_str!("test.other.m3"));
+    assert_eq!(nested.inner.m2.name(), c_str!("m2"));
+    assert_eq!(nested.other.value(), nested.other.default());
+    assert_eq!(nested.other.value(), std::ptr::null_mut());
+}

--- a/rust/ccommon_rs/tests/derive_options.rs
+++ b/rust/ccommon_rs/tests/derive_options.rs
@@ -6,12 +6,11 @@ use ccommon_rs::Options;
 #[derive(Options)]
 #[repr(C)]
 pub struct TestMetrics {
-    #[desc = "A test gauge metric"]
+    #[option(desc = "A test gauge metric")]
     pub m1: Float,
-    #[desc = "A test counter metric"]
+    #[option(desc = "A test counter metric")]
     pub m2: Bool,
-    #[desc = "A test fpn metric"]
-    #[name = "test.other.m3"]
+    #[option(desc = "A test fpn metric", name = "test.other.m3")]
     pub m3: UInt,
 }
 
@@ -19,11 +18,13 @@ pub struct TestMetrics {
 #[repr(C)]
 pub struct Nested {
     pub inner: TestMetrics,
-    #[desc = "Another test metric"]
-    #[name = "nested.other"]
-    #[default(std::ptr::null_mut())]
+    #[option(
+        desc = "Another test metric",
+        name = "nested.other",
+        default = std::ptr::null_mut()
+    )]
     other: Str,
-    #[desc = "Defaulted str"]
+    #[option(desc = "Defaulted str")]
     defaulted: Str,
 }
 


### PR DESCRIPTION
This PR continues upon the changes from #216. It adds complete bindings for metrics and options as well as a box type wrapping `cc_alloc` and `cc_free`.

Here are all the changes
- Update to edition 2018 for macro hygiene reasons
- Implement CCBox
- Wrap the `metric` struct in different types for each type of metric
- Add a `Metrics` trait and a derive macro for this trait
- Wrap the `option` struct in different types for each type of option
- Add a `Options` trait and a derive macro for this trait
- Implement `Metrics` and `Options` manually for all types they apply for in `cc_bindings`