### PR TITLE
Rewrite cmake cargo build wrapper

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -17,6 +17,7 @@ if [[ -n "${RUST_ENABLED:-}" ]]; then
 fi
 
 export RUST_BACKTRACE=full
+export CTEST_OUTPUT_ON_FAILURE=1
 
 mkdir -p _build && ( cd _build && "${cmake_cmd[@]}" .. && make && make test )
 RESULT=$?

--- a/cmake/CMakeCargo.cmake
+++ b/cmake/CMakeCargo.cmake
@@ -1,16 +1,13 @@
-function(cargo_build)
-    cmake_parse_arguments(CARGO "" "NAME" "" ${ARGN})
-    string(REPLACE "-" "_" LIB_NAME ${CARGO_NAME})
 
-    set(CARGO_TARGET_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
+# Get the target that we want to pass to cargo
+function(cargo_build_private_get_target TARGET_VAR)
     if(WIN32)
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
             set(LIB_TARGET "x86_64-pc-windows-msvc")
         else()
             set(LIB_TARGET "i686-pc-windows-msvc")
         endif()
-	elseif(ANDROID)
+    elseif(ANDROID)
         if(ANDROID_SYSROOT_ABI STREQUAL "x86")
             set(LIB_TARGET "i686-linux-android")
         elseif(ANDROID_SYSROOT_ABI STREQUAL "x86_64")
@@ -21,10 +18,10 @@ function(cargo_build)
             set(LIB_TARGET "aarch64-linux-android")
         endif()
     elseif(IOS)
-		set(LIB_TARGET "universal")
+        set(LIB_TARGET "universal")
     elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
         set(LIB_TARGET "x86_64-apple-darwin")
-	else()
+    else()
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
             set(LIB_TARGET "x86_64-unknown-linux-gnu")
         else()
@@ -32,39 +29,291 @@ function(cargo_build)
         endif()
     endif()
 
+    set(${TARGET_VAR} ${LIB_TARGET} PARENT_SCOPE)
+endfunction()
+
+# Get whether to build in release or debug mode
+function(cargo_build_private_get_build_type TARGET_VAR)
     if(NOT CMAKE_BUILD_TYPE)
-        set(LIB_BUILD_TYPE "debug")
+        set(${TARGET_VAR} "debug" PARENT_SCOPE)
     elseif(${CMAKE_BUILD_TYPE} STREQUAL "Release")
-        set(LIB_BUILD_TYPE "release")
+        set(${TARGET_VAR} "release" PARENT_SCOPE)
     else()
-        set(LIB_BUILD_TYPE "debug")
+        set(${TARGET_VAR} "debug" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Create a set of targets to invoke cargo and pass in
+# the required linker flags. This is meant to be run
+# in the same directory as the Cargo.toml file for the
+# library.
+#
+# In all cases, the target can be used as if it was defined
+# through the add_executable or add_binary. In addition,
+# library dependencies will be properly passed through.
+#
+# Arguments:
+#   NAME <lib-name>
+#       The library package name as specified in Cargo.toml.
+#       This argument is required.
+#   TARGET_DIR <dir>
+#       Overrides the default directory for the cargo target
+#       directory which is ${CMAKE_BINARY_DIR}/target.
+#   BIN
+#       Indicates that this crate generated a binary and to
+#       expose that binary file as a target.
+#   STATIC
+#       Indicates this target generates a static library that
+#       can be consumed by other cmake targets.
+#   NO_TEST
+#       Disables generation of the test target.
+#
+# Notes:
+#   - If neither BIN or STATIC is defined then it is assumed
+#     that the target exports no artifacts (i.e. it is only used
+#     by other rust targets within the build)
+#   - Build and exported are currently mutually exclusive. If you
+#     want to have multiple targets like this then call cargo_build
+#     multiple times.
+#
+# Additional Things:
+#   - This also sets up the required cmake properties to delete the
+#     target directory when `make clean` or equivalent is run.
+#
+# How it Works:
+#   In general, cmake has a hard time integrating with external build
+#   systems within the same directory. However, cmake has extensive
+#   support for custom linkers and also allows you to define interface
+#   libraries when no artifact is created. Together, we can use these
+#   to trick cmake into thinking it is building the executable while
+#   actually using cargo to build them. This means that things like
+#   linker flags and dependencies should mostly "just work" (hopefully).
+#
+#   What we have to do depends on what type of library we are compiling:
+#       - For pure rust libraries that don't export any C API, we define
+#         an interface library. This means that any linker flags are
+#         properly passed on to downstream dependencies. In addition, we
+#         define a custom target so the library is built.
+#       - For static libraries, we define a library that's built using a
+#         custom linker language. The custom linker command is really just
+#         a `cargo build` in disguise, but one that passes the correct
+#         flags in.
+#       - For binaries, we define an executable target also using a custom
+#         linker language similar to a static library.
+#
+#   To pass the proper linker flags to the rust process, we have a special
+#   target <NAME>.linkflags.txt that echoes the linker flags into a known
+#   file. These are then picked up by the import-link-flags crate which
+#   uses a build script to pass them to rustc.
+function(cargo_build)
+    cmake_parse_arguments(
+        CARGO
+        "BIN;STATIC;NO_TEST"
+        "NAME;TARGET_DIR;COPY_TO"
+        ""
+        ${ARGN}
+    )
+
+    string(REPLACE "-" "_" LIB_NAME ${CARGO_NAME})
+    if(NOT (DEFINED CARGO_TARGET_DIR))
+        set(CARGO_TARGET_DIR ${CMAKE_BINARY_DIR}/target)
     endif()
 
-    set(LIB_FILE "${CARGO_TARGET_DIR}/${LIB_TARGET}/${LIB_BUILD_TYPE}/${CMAKE_STATIC_LIBRARY_PREFIX}${LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-
-	if(IOS)
-		set(CARGO_ARGS "lipo")
-	else()
-    	set(CARGO_ARGS "build")
-		list(APPEND CARGO_ARGS "--target" ${LIB_TARGET})
-	endif()
-
-    if(${LIB_BUILD_TYPE} STREQUAL "release")
-        list(APPEND CARGO_ARGS "--release")
+    if(CARGO_BIN AND CARGO_STATIC)
+        message(
+            FATAL_ERROR 
+            "Cannot create a cargo target that has is "
+            "both a binary and a static library. Use multiple "
+            "targets instead."
+        )
     endif()
 
-    file(GLOB_RECURSE LIB_SOURCES "*.rs")
+    cargo_build_private_get_target(CRATE_TARGET)
+    cargo_build_private_get_build_type(CRATE_BUILD_TYPE)
 
-    set(CARGO_ENV_COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}")
+    # The CONFIGURE_DEPENDS flag will rerun the glob at build time if the
+    # the build system supports it.
+    file(
+        GLOB_RECURSE
+        CRATE_SOURCES
+        CONFIGURE_DEPENDS
+        "*.rs"
+    )
 
-    add_custom_command(
-        OUTPUT ${LIB_FILE}
-        COMMAND ${CARGO_ENV_COMMAND} ${CARGO_EXECUTABLE} ARGS ${CARGO_ARGS}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS ${LIB_SOURCES}
-        COMMENT "running cargo")
-    add_custom_target(${CARGO_NAME}_target ALL DEPENDS ${LIB_FILE})
-    add_library(${CARGO_NAME} STATIC IMPORTED GLOBAL)
-    add_dependencies(${CARGO_NAME} ${CARGO_NAME}_target)
-    set_target_properties(${CARGO_NAME} PROPERTIES IMPORTED_LOCATION ${LIB_FILE})
+    # Clean the target directory when make clean is run
+    set_directory_properties(PROPERTIES 
+        ADDITIONAL_CLEAN_FILES 
+        ${CARGO_TARGET_DIR}
+    )
+
+    if(CARGO_BIN OR CARGO_STATIC)
+        set(LINK_FLAGS_FILE $<TARGET_FILE:${CARGO_NAME}>.linkflags.txt)
+    else()
+        set(LINK_FLAGS_FILE $<TARGET_FILE:${CARGO_NAME}-link-export>)
+    endif()
+
+    set(FORWARDED_VARS
+        # So that internal invocations of cmake are consistent
+        "CMAKE=${CMAKE_COMMAND}"
+        # So that build scripts can configure themselves based
+        # on whether cmake is driving the build or not
+        "CCOMMON_CMAKE_IS_DRIVING_BUILD=1"
+        # Needed to configure the correct target directory
+        "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
+    )
+
+    if(CARGO_BIN)
+        set(OUTPUT_FILE_NAME ${LIB_NAME}${CMAKE_EXECUTABLE_SUFFIX})
+        set(OUTPUT_FILE ${CARGO_TARGET_DIR}/${CRATE_TARGET}/${OUTPUT_FILE_NAME})
+    elseif(CARGO_STATIC)
+        set(OUTPUT_FILE_NAME ${CMAKE_STATIC_LIBRARY_PREFIX}${LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+        set(OUTPUT_FILE ${CARGO_TARGET_DIR}/${CRATE_TARGET}/${OUTPUT_FILE_NAME})
+    endif()
+
+    if(IOS)
+        # Since we're going through cargo rustc to pass linker flags
+        # this won't work. The previous build script used cargo lipo
+        # here. However, the likelyhood of someone wanting to use
+        # a library for cache servers on IOS is low at this time so
+        # this is OK.
+        message(FATAL_ERROR "Compiling for IOS is not supported")
+    endif()
+
+    # Arguments to cargo
+    set(CRATE_ARGS "")
+    list(APPEND CRATE_ARGS "--target" ${CRATE_TARGET})
+
+    if(CARGO_BIN)
+        list(APPEND CRATE_ARGS "--bin" ${CRATE_TARGET})
+    elseif(CARGO_STATIC)
+        list(APPEND CRATE_ARGS "--lib")
+    else()
+        list(APPEND CRATE_ARGS "--lib")
+    endif()
+
+    if(${CRATE_BUILD_TYPE} STREQUAL "release")
+        list(APPEND CRATE_ARGS "--release")
+    endif()
+
+    # The following is a hack. It takes advantage of the fact that
+    # cmake allows us to define arbitrary linker languages in order
+    # to invoke cargo as our linker command. To do this, we define
+    # a custom language specific to only our target that also takes
+    # in the required environment variables we want to set and the
+    # output file generated by cargo.
+    # 
+    # The upside of this hack is that it allows libraries and binaries
+    # generated by cargo to be used as normal cmake targets. This
+    # means that stuff like target_link_libraries works properly.
+    #
+    # Extra Note: The variables that look like <VAR_NAME> in the string
+    #   below are called expansion variables by the community wiki. They
+    #   don't seem to be documented anywhere in the official docs but
+    #   are hopefully stable.
+    #
+    # Another Note: Since these are required to be global variables we
+    #   push them in the cache as hidden variables.
+    #
+    # The inspiration for this hack came from this SO answer
+    # https://stackoverflow.com/questions/34165365/retrieve-all-link-flags-in-cmake
+    #
+    # "Docs" for the expansion rules can be found here
+    # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/Build-Rules
+    set(
+        LINK_COMMAND
+        "bash -c \""
+            "<CMAKE_COMMAND> -E echo_append <LINK_FLAGS> <LINK_LIBRARIES> > <TARGET>.linkflags.txt"
+            "&& <CMAKE_COMMAND> -E env ${FORWARDED_VARS} 'CCOMMON_LINK_FLAGS_FILE=<TARGET>.linkflags.txt' cargo build <FLAGS>"
+            "&& <CMAKE_COMMAND> -E copy '${OUTPUT_FILE}' <TARGET>"
+        "\""
+    )
+    
+    set(CMAKE_${CARGO_NAME}_LINK_EXECUTABLE "${LINK_COMMAND}" CACHE INTERNAL "")
+    set(CMAKE_${CARGO_NAME}_CREATE_STATIC_LIBRARY "${LINK_COMMAND}" CACHE INTERNAL "")
+    set(CMAKE_${CARGO_NAME}_CREATE_SHARED_LIBRARY "${LINK_COMMAND}" CACHE INTERNAL "")
+    set(CMAKE_${CARGO_NAME}_LINK_FLAGS ${CMAKE_C_LINK_FLAGS} CACHE INTERNAL "")
+    set(CMAKE_${CARGO_NAME}_LINK_DIRECTORIES ${CMAKE_C_LINK_DIRECTORIES} CACHE INTERNAL "")
+
+    # Needed to build when we have test targets
+    set(
+        CMAKE_ECHO_LINK_EXECUTABLE
+        "bash -c \"<CMAKE_COMMAND> -E echo_append <LINK_FLAGS> <LINK_LIBRARIES> > <TARGET>\""
+        CACHE INTERNAL ""
+    )
+    set(CMAKE_ECHO_LINK_FLAGS ${CMAKE_C_LINK_FLAGS} CACHE INTERNAL "")
+    set(CMAKE_ECHO_LINK_DIRECTORIES ${CMAKE_C_LINK_DIRECTORIES} CACHE INTERNAL "")
+
+    # Targets
+    if(CARGO_BIN)
+        # We are building a binary executable
+        add_executable(
+            ${CARGO_NAME}
+            ${CRATE_SOURCES}
+        )
+        
+        # Ensure that we use our custom "linker"
+        set_target_properties(
+            ${CARGO_NAME} PROPERTIES
+            LINKER_LANGUAGE ${CARGO_NAME}
+        )
+
+        target_compile_options(${CARGO_NAME} PRIVATE ${CRATE_ARGS})
+    elseif(CARGO_STATIC)
+        # We are building a static library that will be used from C code
+        add_library(
+            ${CRATE_NAME}
+            STATIC
+            ${CRATE_SOURCES}
+        )
+
+        # Ensure that we use our custom "linker"
+        set_target_properties(
+            ${CARGO_NAME} PROPERTIES
+            LINKER_LANGUAGE ${CARGO_NAME}
+        )
+
+        target_compile_options(${CARGO_NAME} PRIVATE ${CRATE_ARGS})
+    else()
+        # We are building a rust-only library. Define it as a interface library
+        add_library(
+            ${CARGO_NAME}
+            INTERFACE
+        )
+
+        # However, we still want to build the library, so define a custom command for that
+        add_custom_command(
+            # Dummy file to ensure that the command always runs
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/DOES_NOT_EXIST
+            COMMAND ${CARGO_ENV_COMMAND} ${CARGO_EXECUTABLE} build ${CRATE_ARGS}
+            DEPENDS ${CRATE_SOURCES}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "running cargo for target ${CARGO_NAME}"
+        )
+
+        add_custom_target(
+            ${CARGO_NAME}-build
+            ALL DEPENDS 
+            ${CMAKE_CURRENT_BINARY_DIR}/DOES_NOT_EXIST
+        )
+
+        add_dependencies(${CARGO_NAME} ${CARGO_NAME}-build)
+        add_dependencies(${CARGO_NAME} ${CARGO_NAME}-link-export)
+
+        add_executable(${CARGO_NAME}-link-export Cargo.toml)
+        set_target_properties(
+            ${CARGO_NAME}-link-export PROPERTIES
+            LINKER_LANGUAGE ECHO
+            SUFFIX          ".txt"
+            TARGET_MESSAGES OFF
+        )
+        target_link_libraries(${CARGO_NAME}-link-export $<TARGET_PROPERTY:${CARGO_NAME},INTERFACE_LINK_LIBRARIES>)
+    endif()
+
+    if(NOT CARGO_NO_TEST)
+        add_test(
+            NAME ${CARGO_NAME}-test
+            COMMAND ${CMAKE_COMMAND} -E env ${FORWARDED_VARS} "CCOMMON_LINK_FLAGS_FILE=${LINK_FLAGS_FILE}" cargo test ${CRATE_ARGS}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+    endif()
 endfunction()

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -9,4 +9,7 @@ execute_process(
 
 if(HAVE_RUST)
     add_subdirectory(ccommon_rs)
+    add_subdirectory(cc_binding)
+    add_subdirectory(ccommon-derive)
+    add_subdirectory(import-link-flags)
 endif()

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,8 @@
 members = [
     "cc_binding",
     "ccommon_rs",
-    "ccommon-derive"
+    "ccommon-derive",
+    "import-link-flags"
 ]
 
 [profile.release]
@@ -17,6 +18,3 @@ codegen-units = 1
 [profile.dev]
 debug = true
 opt-level = 0
-
-[term]
-verbose = true

--- a/rust/cc_binding/CMakeLists.txt
+++ b/rust/cc_binding/CMakeLists.txt
@@ -1,4 +1,6 @@
 cargo_build(NAME cc_binding)
 
-add_dependencies(cc_binding_static ccommon-static)
-add_dependencies(cc_binding_shared ccommon-shared)
+target_link_libraries(cc_binding INTERFACE ccommon-static)
+
+add_dependencies(cc_binding ccommon-static)
+add_dependencies(cc_binding import-link-flags)

--- a/rust/cc_binding/Cargo.toml
+++ b/rust/cc_binding/Cargo.toml
@@ -10,6 +10,7 @@ failure = "0.1.5"
 
 [dependencies]
 libc = "0.2.0"
+import-link-flags = { path="../import-link-flags" }
 
 [lib]
 name = "cc_binding"

--- a/rust/ccommon-derive/CMakeLists.txt
+++ b/rust/ccommon-derive/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+cargo_build(NAME ccommon-derive)
+
+add_dependencies(ccommon-derive import-link-flags)
+
+target_link_libraries(ccommon-derive INTERFACE import-link-flags)

--- a/rust/ccommon-derive/Cargo.toml
+++ b/rust/ccommon-derive/Cargo.toml
@@ -13,3 +13,4 @@ syn = { version = "1.0.0", features = [ "parsing" ] }
 quote = "1.0.0"
 proc-macro2 = "1.0.0"
 proc-macro-crate = "0.1.4"
+import-link-flags = { path="../import-link-flags" }

--- a/rust/ccommon_rs/CMakeLists.txt
+++ b/rust/ccommon_rs/CMakeLists.txt
@@ -1,3 +1,9 @@
 file(WRITE CMAKE_BINARY_DIR "${CMAKE_BINARY_DIR}\n")
+
 cargo_build(NAME ccommon_rs)
-add_dependencies(ccommon_rs ccommon-static)
+
+add_dependencies(ccommon_rs cc_binding)
+add_dependencies(ccommon_rs ccommon-derive)
+add_dependencies(ccommon_rs import-link-flags)
+
+target_link_libraries(ccommon_rs INTERFACE cc_binding ccommon-derive import-link-flags)

--- a/rust/ccommon_rs/Cargo.toml
+++ b/rust/ccommon_rs/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["staticlib", "rlib"]
 cc_binding = { path = "../cc_binding" }
 libc = "0.2.0"
 log = "0.4.0"
+import-link-flags = { path="../import-link-flags" }
 
 [dependencies.ccommon-derive]
 path = "../ccommon-derive"

--- a/rust/import-link-flags/CMakeLists.txt
+++ b/rust/import-link-flags/CMakeLists.txt
@@ -1,0 +1,1 @@
+cargo_build(NAME import-link-flags)

--- a/rust/import-link-flags/Cargo.toml
+++ b/rust/import-link-flags/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "import-link-flags"
+version = "0.1.0"
+authors = ["Sean Lynch <slynch@twitter.com>"]
+edition = "2018"
+
+[dependencies]

--- a/rust/import-link-flags/build.rs
+++ b/rust/import-link-flags/build.rs
@@ -1,0 +1,71 @@
+
+use std::path::Path;
+use std::io::Read;
+use std::env;
+use std::fs::File;
+
+fn process_flags(flags: &str) {
+    eprintln!("{}", flags);
+
+    let flags = flags.split(" ");
+    let mut prev = None;
+
+    for flag in flags {
+        if flag == "" {
+            continue;
+        }
+        
+        if let Some(prevflag) = prev {
+            println!("cargo:rustc-flags={} {}", prevflag, flag);
+            prev = None;
+            continue;
+        }
+
+        if flag == "-l" || flag == "-L" {
+            prev = Some(flag);
+            continue;   
+        }
+
+        let path = Path::new(flag);
+        if !path.is_file() && path.exists() {
+            panic!("Attempting to link to {} which is not a file", flag);
+        }
+
+        if let Some(parent) = path.parent() {
+            println!("cargo:rustc-flags=-L{}", parent.display());
+        }
+
+        let filename = match path.file_name() {
+            Some(filename) => filename,
+            None => panic!("Attempted to link to a directory: {}", path.display())
+        };
+
+        println!("cargo:rustc-flags=-l{}", Path::new(filename).display());
+    }
+
+    if let Some(prev) = prev {
+        panic!("Unmatched '{}' flag", prev);
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CCOMMON_LINK_FLAGS_FILE");
+
+    if let Some(var) = env::var_os("CCOMMON_LINK_FLAGS_FILE") {
+        let path = Path::new(&var);
+
+        println!("cargo:rerun-if-changed={}", path.display());
+
+        let mut file = match File::open(&path) {
+            Ok(file) => file,
+            Err(e) => panic!("Unable to open file {}: {}", path.display(), e)
+        };
+
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).expect("Failed to read file");
+
+        let flags = String::from_utf8(bytes).expect("Build flags contained invalid utf8");
+        process_flags(&flags);
+    }
+}

--- a/rust/import-link-flags/src/lib.rs
+++ b/rust/import-link-flags/src/lib.rs
@@ -1,0 +1,1 @@
+//! Library for importing link flags from the current cmake instance

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -3,12 +3,7 @@ set(test_name check_${suite})
 
 set(source check_${suite}.c)
 
-if(HAVE_RUST)
-    set(CCOMMON_LIBS ccommon_rs) # common_rs_static staticly links common-static
-else()
-    set(CCOMMON_LIBS ccommon-static)
-endif()
-
+set(CCOMMON_LIBS ccommon-static)
 
 add_executable(${test_name} ${source})
 target_link_libraries(


### PR DESCRIPTION
Problem
The cmake code that handles building rust projects doesn't properly pass through linker flags. In addition, since it generates custom targets, C dependencies of rust code can't use target_link_libraries. (This relevant for pelikan, not so much ccommon).

To resolve this, this PR rewrites the cmake code that handles the integration of cargo into the project. It changes the targets generated by cmake to be real library/executable targets. As a result, they now propagate linker flags properly and can be used for target_link_libraries of dependent targets.

For an explanation of the details of how everything works, see the comment for the cargo_build function in CMakeCargo.cmake