### PR TITLE
Conditionally use std::any::type_name if it's supported

### DIFF
--- a/rust/ccommon_rs/Cargo.toml
+++ b/rust/ccommon_rs/Cargo.toml
@@ -22,6 +22,9 @@ log = "0.4.0"
 path = "../ccommon-derive"
 optional = true
 
+[build-dependencies]
+autocfg = "0.1.7"
+
 [dev-dependencies]
 rusty-fork = "0.2.0"
 gag = "0.1.10"

--- a/rust/ccommon_rs/build.rs
+++ b/rust/ccommon_rs/build.rs
@@ -1,0 +1,23 @@
+// ccommon - a cache common library.
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use autocfg::AutoCfg;
+
+fn main() {
+    let cfg = AutoCfg::new().unwrap();
+
+    // For rust versions >= 1.38 we can use std::any::type_name
+    cfg.emit_rustc_version(1, 38);
+}

--- a/rust/ccommon_rs/src/error.rs
+++ b/rust/ccommon_rs/src/error.rs
@@ -75,12 +75,22 @@ impl<T> AllocationError<T> {
 
 impl<T> Display for AllocationError<T> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        write!(
+        #[cfg(rustc_1_38)]
+        let res = write!(
             fmt,
             "Unable to allocate a value of type {} with size {}",
             std::any::type_name::<T>(),
             std::mem::size_of::<T>()
-        )
+        );
+
+        #[cfg(not(rustc_1_38))]
+        let res = write!(
+            fmt,
+            "Unable to allocate a value of size {}",
+            std::mem::size_of::<T>()
+        );
+
+        res
     }
 }
 impl<T> Debug for AllocationError<T> {


### PR DESCRIPTION
Problem
`std::any::type_name` is used for better error messages. However, it was only introduced in rust 1.38 while it would be useful to have ccommon useable under rust 1.37.

Solution
This PR uses autocfg to check the rustc version and conditionally switch between the implementations when supported.
