### PR TITLE
Make cc_binding generate bindings recursively

### DIFF
--- a/rust/cc_binding/build.rs
+++ b/rust/cc_binding/build.rs
@@ -110,7 +110,12 @@ fn main() {
         ])
         .header("wrapper.h")
         .prepend_enum_name(false)
-        .whitelist_recursively(false)
+        .whitelist_recursively(true)
+
+        // C stdlib types that we want to get from the libc crate
+        .blacklist_type("FILE")
+        .blacklist_type("addrinfo")
+        .blacklist_type("timespec")
 
         // We provide a custom binding of metric with atomic types
         .blacklist_type("metric")


### PR DESCRIPTION
Problem
cc_binding fails to build with certain gcc versions because bindgen misses some typedefs while generating bindings.

Solution
Make bindgen recursively generate the needed bindings from the initial whitelist.

