### PR TITLE
Use name of field instead of description for C metrics

### DIFF
--- a/rust/ccommon_rs/src/metric/mod.rs
+++ b/rust/ccommon_rs/src/metric/mod.rs
@@ -177,7 +177,7 @@ mod impls {
                         Self {
                             $(
                                 $field: metric {
-                                    name: c_str!($desc),
+                                    name: c_str!(stringify!($field)),
                                     type_: $type,
                                     desc: c_str!($desc),
                                     data: initialize_metric_value!($type)


### PR DESCRIPTION
Problem
C metrics that are manually wrapped in ccommon_rs put the description in the name field instead of the actual name of the metric.

Solution
Use the actual name of the metric.
