### PR TITLE
Fix clippy lints in code

### DIFF
--- a/rust/cc_binding/src/lib.rs
+++ b/rust/cc_binding/src/lib.rs
@@ -21,13 +21,14 @@
 //! ```
 //!
 
-#![allow(unknown_lints)]
-#![allow(clippy)]
-#![allow(clippy_pedantic)]
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(dead_code)]
+#![allow(
+    unknown_lints,
+    clippy::all,
+    non_upper_case_globals,
+    non_camel_case_types,
+    non_snake_case,
+    dead_code
+)]
 
 #[path = "metric.rs"]
 mod metric_impl;

--- a/rust/ccommon-backend/src/option/default.rs
+++ b/rust/ccommon-backend/src/option/default.rs
@@ -38,6 +38,12 @@ impl fmt::Display for OutOfMemoryError {
 impl std::error::Error for OutOfMemoryError {}
 
 /// Initialize an option to it's default value.
+/// 
+/// # Safety
+/// This function assumes that the description and name
+/// pointers within the options always point to a valid
+/// C string. It also assumes that the value for string
+/// type options is either a valid C string or null.
 pub unsafe fn option_default(opt: &mut option) -> Result<(), OutOfMemoryError> {
     use std::mem::MaybeUninit;
 
@@ -77,6 +83,12 @@ pub unsafe fn option_default(opt: &mut option) -> Result<(), OutOfMemoryError> {
 }
 
 /// Initialize all the options to their default values.
+/// 
+/// # Safety
+/// This function assumes that the description and name
+/// pointers within the options always point to a valid
+/// C string. It also assumes that the value for string
+/// type options is either a valid C string or null.
 pub unsafe fn option_load_default(options: &mut [option]) -> Result<(), OutOfMemoryError> {
     for opt in options.iter_mut() {
         option_default(opt)?;

--- a/rust/ccommon-backend/src/option/default.rs
+++ b/rust/ccommon-backend/src/option/default.rs
@@ -38,7 +38,7 @@ impl fmt::Display for OutOfMemoryError {
 impl std::error::Error for OutOfMemoryError {}
 
 /// Initialize an option to it's default value.
-/// 
+///
 /// # Safety
 /// This function assumes that the description and name
 /// pointers within the options always point to a valid
@@ -83,7 +83,7 @@ pub unsafe fn option_default(opt: &mut option) -> Result<(), OutOfMemoryError> {
 }
 
 /// Initialize all the options to their default values.
-/// 
+///
 /// # Safety
 /// This function assumes that the description and name
 /// pointers within the options always point to a valid

--- a/rust/ccommon-backend/src/option/print.rs
+++ b/rust/ccommon-backend/src/option/print.rs
@@ -35,7 +35,7 @@ fn fmt_type(ty: option_type) -> &'static str {
     }
 }
 
-fn fmt_value<W: Write>(writer: &mut W, val: &option_val, ty: option_type) -> Result<()> {
+fn fmt_value<W: Write>(writer: &mut W, val: option_val, ty: option_type) -> Result<()> {
     unsafe {
         match ty {
             OPTION_TYPE_BOOL => write!(writer, "{: <20}", if val.vbool { "yes" } else { "no" }),
@@ -53,6 +53,13 @@ fn fmt_value<W: Write>(writer: &mut W, val: &option_val, ty: option_type) -> Res
     }
 }
 
+/// Print a single option.
+/// 
+/// # Safety
+/// This function assumes that the description and name
+/// pointers within the options always point to a valid
+/// C string. It also assumes that the value for string
+/// type options is either a valid C string or null.
 pub unsafe fn option_print<W: Write>(writer: &mut W, opt: &option) -> Result<()> {
     write!(
         writer,
@@ -60,12 +67,19 @@ pub unsafe fn option_print<W: Write>(writer: &mut W, opt: &option) -> Result<()>
         fmt_cstr(opt.name),
         fmt_type(opt.type_)
     )?;
-    fmt_value(writer, &opt.val, opt.type_)?;
+    fmt_value(writer, opt.val, opt.type_)?;
     write!(writer, " (default: ")?;
-    fmt_value(writer, &opt.default_val, opt.type_)?;
+    fmt_value(writer, opt.default_val, opt.type_)?;
     writeln!(writer, ")")
 }
 
+/// Print all options.
+/// 
+/// # Safety
+/// This function assumes that the description and name
+/// pointers within the options always point to a valid
+/// C string. It also assumes that the value for string
+/// type options is either a valid C string or null.
 pub unsafe fn option_print_all<W: Write>(writer: &mut W, options: &[option]) -> Result<()> {
     for opt in options.iter() {
         option_print(writer, opt)?;
@@ -74,15 +88,29 @@ pub unsafe fn option_print_all<W: Write>(writer: &mut W, options: &[option]) -> 
     Ok(())
 }
 
+/// Describe a single option.
+/// 
+/// # Safety
+/// This function assumes that the description and name
+/// pointers within the options always point to a valid
+/// C string. It also assumes that the value for string
+/// type options is either a valid C string or null.
 pub unsafe fn option_describe<W: Write>(writer: &mut W, opt: &option) -> Result<()> {
     let name = fmt_cstr(opt.name);
     let desc = fmt_cstr(opt.description);
 
     write!(writer, "{: <31} {: <15} ", name, fmt_type(opt.type_))?;
-    fmt_value(writer, &opt.default_val, opt.type_)?;
+    fmt_value(writer, opt.default_val, opt.type_)?;
     writeln!(writer, " {}\n", desc)
 }
 
+/// Describe all options.
+/// 
+/// # Safety
+/// This function assumes that the description and name
+/// pointers within the options always point to a valid
+/// C string. It also assumes that the value for string
+/// type options is either a valid C string or null.
 pub unsafe fn option_describe_all<W: Write>(writer: &mut W, options: &[option]) -> Result<()> {
     for opt in options.iter() {
         option_describe(writer, opt)?;

--- a/rust/ccommon-backend/src/option/print.rs
+++ b/rust/ccommon-backend/src/option/print.rs
@@ -54,7 +54,7 @@ fn fmt_value<W: Write>(writer: &mut W, val: option_val, ty: option_type) -> Resu
 }
 
 /// Print a single option.
-/// 
+///
 /// # Safety
 /// This function assumes that the description and name
 /// pointers within the options always point to a valid
@@ -74,7 +74,7 @@ pub unsafe fn option_print<W: Write>(writer: &mut W, opt: &option) -> Result<()>
 }
 
 /// Print all options.
-/// 
+///
 /// # Safety
 /// This function assumes that the description and name
 /// pointers within the options always point to a valid
@@ -89,7 +89,7 @@ pub unsafe fn option_print_all<W: Write>(writer: &mut W, options: &[option]) -> 
 }
 
 /// Describe a single option.
-/// 
+///
 /// # Safety
 /// This function assumes that the description and name
 /// pointers within the options always point to a valid
@@ -105,7 +105,7 @@ pub unsafe fn option_describe<W: Write>(writer: &mut W, opt: &option) -> Result<
 }
 
 /// Describe all options.
-/// 
+///
 /// # Safety
 /// This function assumes that the description and name
 /// pointers within the options always point to a valid

--- a/rust/ccommon-derive/src/attrs.rs
+++ b/rust/ccommon-derive/src/attrs.rs
@@ -58,7 +58,7 @@ impl Parse for StrOrExpr {
 }
 
 impl AttrOption<StrOrExpr> {
-    pub fn as_lit(self) -> Result<EqOption> {
+    pub fn into_lit(self) -> Result<EqOption> {
         match self.val {
             StrOrExpr::Str(s) => Ok(EqOption {
                 name: self.name,
@@ -72,7 +72,7 @@ impl AttrOption<StrOrExpr> {
         }
     }
 
-    pub fn as_expr(self) -> ExprOption {
+    pub fn into_expr(self) -> ExprOption {
         let expr = match self.val {
             StrOrExpr::Str(s) => parse_quote!(#s),
             StrOrExpr::Expr(e) => e,
@@ -146,9 +146,9 @@ impl Parse for OptionAttr {
             let span = val.span();
             let param = val.name.to_string();
             let seen = match &*param {
-                "desc" => mem::replace(&mut desc, Some(val.as_lit()?)).is_some(),
-                "name" => mem::replace(&mut name, Some(val.as_lit()?)).is_some(),
-                "default" => mem::replace(&mut default, Some(val.as_expr())).is_some(),
+                "desc" => mem::replace(&mut desc, Some(val.into_lit()?)).is_some(),
+                "name" => mem::replace(&mut name, Some(val.into_lit()?)).is_some(),
+                "default" => mem::replace(&mut default, Some(val.into_expr())).is_some(),
                 _ => return Err(Error::new(span, format!("Unknown option `{}`", param))),
             };
 

--- a/rust/ccommon-derive/src/lib.rs
+++ b/rust/ccommon-derive/src/lib.rs
@@ -160,12 +160,9 @@ fn derive_metrics_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
     let process_field = |is_tuple| {
         let krate = krate.clone();
         move |(i, field): (usize, &Field)| {
-            let ref ty = field.ty;
-            let ref name = field.ident;
-            let label = match is_tuple {
-                true => quote! {},
-                false => quote! { #name: },
-            };
+            let ty = &field.ty;
+            let name = &field.ident;
+            let label = if is_tuple { quote! {} } else { quote! { #name: } };
 
             Ok(match get_metric_attr(&field.attrs)? {
                 Some(attr) => {
@@ -229,8 +226,7 @@ fn derive_metrics_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
                 #initializer
             }
         }
-    }
-    .into())
+    })
 }
 
 fn derive_options_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
@@ -273,12 +269,9 @@ fn derive_options_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
     let process_field = |is_tuple| {
         let krate = krate.clone();
         move |(i, field): (usize, &Field)| {
-            let ref ty = field.ty;
-            let ref name = field.ident;
-            let label = match is_tuple {
-                true => quote! {},
-                false => quote! { #name: },
-            };
+            let ty = &field.ty;
+            let name = &field.ident;
+            let label = if is_tuple { quote! {} } else { quote! { #name: } };
 
             Ok(match get_option_attr(&field.attrs)? {
                 Some(attr) => {
@@ -347,8 +340,7 @@ fn derive_options_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
                 #initializer
             }
         }
-    }
-    .into())
+    })
 }
 
 fn crate_name(name: &'static str) -> Result<TokenStream, Error> {
@@ -480,9 +472,9 @@ fn is_repr_c_or_transparent(attrs: &[Attribute]) -> bool {
         }
     }
 
-    return false;
+    false
 }
 
 fn has_generics(generics: &Generics) -> bool {
-    return generics.lt_token.is_some() || generics.where_clause.is_some();
+    generics.lt_token.is_some() || generics.where_clause.is_some()
 }

--- a/rust/ccommon-derive/src/lib.rs
+++ b/rust/ccommon-derive/src/lib.rs
@@ -162,7 +162,11 @@ fn derive_metrics_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
         move |(i, field): (usize, &Field)| {
             let ty = &field.ty;
             let name = &field.ident;
-            let label = if is_tuple { quote! {} } else { quote! { #name: } };
+            let label = if is_tuple {
+                quote! {}
+            } else {
+                quote! { #name: }
+            };
 
             Ok(match get_metric_attr(&field.attrs)? {
                 Some(attr) => {
@@ -271,7 +275,11 @@ fn derive_options_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, E
         move |(i, field): (usize, &Field)| {
             let ty = &field.ty;
             let name = &field.ident;
-            let label = if is_tuple { quote! {} } else { quote! { #name: } };
+            let label = if is_tuple {
+                quote! {}
+            } else {
+                quote! { #name: }
+            };
 
             Ok(match get_option_attr(&field.attrs)? {
                 Some(attr) => {

--- a/rust/ccommon_rs/src/bstring.rs
+++ b/rust/ccommon_rs/src/bstring.rs
@@ -98,11 +98,11 @@ impl BStr {
         self as *const _ as *mut _
     }
 
-    pub fn from_ref<'a>(ccb: &'a CCbstring) -> &'a Self {
+    pub fn from_ref(ccb: &CCbstring) -> &Self {
         unsafe { Self::from_ptr(ccb as *const CCbstring as *mut _) }
     }
 
-    pub fn to_utf8_str<'a>(&'a self) -> Result<&'a str, Utf8Error> {
+    pub fn to_utf8_str(&self) -> Result<&str, Utf8Error> {
         str::from_utf8(&self[..])
     }
 
@@ -281,8 +281,8 @@ impl BString {
     /// # Panics
     ///
     /// This method will panic if `src.len() != self.len()`
-    #[allow(dead_code)]
     #[inline]
+    // Note: Used for tests
     #[allow(dead_code)]
     fn copy_from_slice(&mut self, src: &[u8]) {
         assert_eq!(src.len(), self.len());
@@ -304,7 +304,7 @@ impl BString {
         unsafe { (*self.0).len as usize }
     }
 
-    pub fn to_utf8_str<'a>(&'a self) -> Result<&'a str, Utf8Error> {
+    pub fn to_utf8_str(&self) -> Result<&str, Utf8Error> {
         str::from_utf8(self.as_bytes())
     }
 

--- a/rust/ccommon_rs/src/buf.rs
+++ b/rust/ccommon_rs/src/buf.rs
@@ -33,18 +33,40 @@ pub struct Buf {
 }
 
 impl Buf {
+    pub unsafe fn from_ptr<'a>(buf: *const buf) -> &'a Buf {
+        &*(buf as *const Buf)
+    }
+
+    pub unsafe fn from_mut_ptr<'a>(buf: *mut buf) -> &'a mut Buf {
+        &mut *(buf as *mut Buf)
+    }
+
+    pub fn as_ptr(&self) -> *const buf {
+        &self.buf as *const buf
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut buf {
+        &mut self.buf as *mut buf
+    }
+
+    #[deprecated(note = "use from_ptr instead")]
     pub unsafe fn from_raw<'a>(buf: *const buf) -> &'a Buf {
         &*(buf as *const Buf)
     }
 
+    #[deprecated(note = "use from_mut_ptr instead")]
     pub unsafe fn from_raw_mut<'a>(buf: *mut buf) -> &'a mut Buf {
         &mut *(buf as *mut Buf)
     }
 
+    #[deprecated(note = "use as_ptr instead")]
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_raw(&self) -> *const buf {
         &self.buf as *const _
     }
 
+    #[deprecated(note = "use as_mut_ptr instead")]
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_raw_mut(&mut self) -> *mut buf {
         &mut self.buf as *mut _
     }
@@ -74,7 +96,7 @@ impl Buf {
     pub fn new_cap(&self, bytes: usize) -> usize {
         assert!(unsafe { self.buf.begin.as_ptr() } as usize <= self.buf.wpos as usize);
 
-        return bytes.saturating_sub(self.write_size());
+        bytes.saturating_sub(self.write_size())
     }
 
     /// Clear the buffer and remove it from any allocation pool
@@ -226,13 +248,13 @@ impl Deref for OwnedBuf {
     type Target = Buf;
 
     fn deref(&self) -> &Buf {
-        unsafe { Buf::from_raw(self.buf) }
+        unsafe { Buf::from_ptr(self.buf) }
     }
 }
 
 impl DerefMut for OwnedBuf {
     fn deref_mut(&mut self) -> &mut Buf {
-        unsafe { Buf::from_raw_mut(self.buf) }
+        unsafe { Buf::from_mut_ptr(self.buf) }
     }
 }
 

--- a/rust/ccommon_rs/src/log/shim.rs
+++ b/rust/ccommon_rs/src/log/shim.rs
@@ -87,7 +87,7 @@ impl Log for CCLog {
         let filestr = record
             .file()
             .or_else(|| record.module_path())
-            .unwrap_or(record.target());
+            .unwrap_or_else(|| record.target());
         let _ = write!(&mut filename[0..FILENAME_MAX_LEN], "{}", filestr);
 
         unsafe {
@@ -198,11 +198,11 @@ pub fn set_panic_handler() {
 
         let old_val = env::var_os("RUST_BACKTRACE");
         // If possible, have the stdlib display a backtrace
-        let _ = env::set_var("RUST_BACKTRACE", "full");
+        env::set_var("RUST_BACKTRACE", "full");
         old_hook(info);
 
         if let Some(var) = old_val {
-            let _ = env::set_var("RUST_BACKTRACE", var);
+            env::set_var("RUST_BACKTRACE", var);
         }
     }))
 }

--- a/rust/ccommon_rs/src/option/mod.rs
+++ b/rust/ccommon_rs/src/option/mod.rs
@@ -189,6 +189,7 @@ pub trait OptionExt: Options {
 
     /// Load options from a file.
     #[deprecated(note = "Use load instead - this interface is unsafe")]
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn load_from_libc_file(&mut self, file: *mut libc::FILE) -> Result<(), crate::Error> {
         use ccommon_backend::compat::CFileRef;
         use std::io::BufReader;

--- a/rust/ccommon_rs/src/option/mod.rs
+++ b/rust/ccommon_rs/src/option/mod.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 //! Types and methods for dealing with ccommon options.
-//! 
+//!
 //! See the docs on the `Options` macro to see how to create
 //! new options structs.
 


### PR DESCRIPTION
Problem
We have a bunch of rust code that causes warnings when run through clippy. This usually means that it doesn't follow best practices. It also blocks us from running clippy as a pre-commit check.

Solution
Fix the warnings where possible and silence (and deprecate the methods + provide new equivalent once) when not possible.