### PR TITLE
Update to use bytes v5.0

### DIFF
--- a/rust/ccommon_rs/Cargo.toml
+++ b/rust/ccommon_rs/Cargo.toml
@@ -14,7 +14,7 @@ cc_binding = { path="../cc_binding" }
 ccommon-backend = { path="../ccommon-backend" }
 libc = "0.2.0"
 log = "0.4.0"
-bytes = "0.4.12"
+bytes = "0.5.0"
 
 [dependencies.ccommon-derive]
 path = "../ccommon-derive"

--- a/rust/ccommon_rs/src/buf.rs
+++ b/rust/ccommon_rs/src/buf.rs
@@ -16,6 +16,7 @@
 use cc_binding::buf;
 
 use std::io::{self, Read, Write};
+use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 
 use bytes::{Buf as BytesBuf, BufMut as BytesBufMut};
@@ -329,8 +330,10 @@ impl BytesBufMut for Buf {
         self.buf.wpos = self.buf.wpos.wrapping_add(cnt);
     }
 
-    unsafe fn bytes_mut(&mut self) -> &mut [u8] {
-        std::slice::from_raw_parts_mut(self.buf.wpos as *mut u8, self.write_size())
+    fn bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        unsafe {
+            std::slice::from_raw_parts_mut(self.buf.wpos as *mut MaybeUninit<u8>, self.write_size())
+        }
     }
 }
 
@@ -357,7 +360,7 @@ impl BytesBufMut for OwnedBuf {
         (**self).advance_mut(cnt)
     }
 
-    unsafe fn bytes_mut(&mut self) -> &mut [u8] {
+    fn bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
         BytesBufMut::bytes_mut(&mut **self)
     }
 }


### PR DESCRIPTION
Problem
In order to update to the non-alpha version of tokio it is necessary to update the bytes crate.

Solution
Updated the bytes crate.

