### PR TITLE
improve cargo build script

### DIFF
--- a/ci/cargo.sh
+++ b/ci/cargo.sh
@@ -20,7 +20,8 @@ cat > Cargo.toml <<HEADER
 members = [
 HEADER
 
-for CRATE_ROOT in `find rust -type d -mindepth 1 -maxdepth 1`; do
+for CRATE_MANIFEST in `find rust -type f -name "Cargo.toml"`; do
+  CRATE_ROOT=`dirname ${CRATE_MANIFEST}`
   echo "\"${CRATE_ROOT}\"," >> Cargo.toml
 done
 


### PR DESCRIPTION
Improves the cargo build script by fixing some of the logic around
generating the list of manifests to include in the temporary
workspace virtual manifest.

Previously, if there were extra directories in the rust directory,
the script would assume there were cargo manifests directly within
them.

Changes the find command to look for cargo manifests and include
the parent directory of any manifest file in the virtual manifest.
