### PR TITLE
add new libraries to contain config structs

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -8,9 +8,16 @@ execute_process(
     ERROR_VARIABLE CARGO_CONFIG_OUT)
 
 if(HAVE_RUST)
-	add_subdirectory(ccommon-backend)
-	add_subdirectory(ccommon-derive)
+    add_subdirectory(ccommon-array)
+    add_subdirectory(ccommon-backend)
+    add_subdirectory(ccommon-buffer)
+    add_subdirectory(ccommon-channel)
+    add_subdirectory(ccommon-derive)
+    add_subdirectory(ccommon-log)
     add_subdirectory(ccommon-rs)
+    add_subdirectory(ccommon-stats)
+    add_subdirectory(ccommon-stream)
     add_subdirectory(ccommon-sys)
+    add_subdirectory(ccommon-time)
     
 endif()

--- a/rust/ccommon-array/CMakeLists.txt
+++ b/rust/ccommon-array/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+cargo_build(NAME ccommon-array)

--- a/rust/ccommon-array/Cargo.toml
+++ b/rust/ccommon-array/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ccommon-array"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.110", features = ["derive"], optional = true }
+
+[features]
+default = [ "serde/derive" ]

--- a/rust/ccommon-array/src/lib.rs
+++ b/rust/ccommon-array/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const NELEM_DELTA: usize = 16;
+
+// helper functions
+fn nelem_delta() -> usize {
+    NELEM_DELTA
+}
+
+// definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ArrayConfig {
+    #[cfg_attr(feature = "serde", serde(default = "nelem_delta"))]
+    nelem_delta: usize,
+}
+
+// implementation
+impl ArrayConfig {
+    pub fn nelem_delta(&self) -> usize {
+        self.nelem_delta
+    }
+}
+
+// trait implementations
+impl Default for ArrayConfig {
+    fn default() -> Self {
+        Self {
+            nelem_delta: nelem_delta(),
+        }
+    }
+}

--- a/rust/ccommon-buffer/CMakeLists.txt
+++ b/rust/ccommon-buffer/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+cargo_build(NAME ccommon-buffer)

--- a/rust/ccommon-buffer/Cargo.toml
+++ b/rust/ccommon-buffer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ccommon-buffer"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.110", features = ["derive"], optional = true }
+
+[features]
+default = [ "serde/derive" ]
+

--- a/rust/ccommon-buffer/src/buf/mod.rs
+++ b/rust/ccommon-buffer/src/buf/mod.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const BUF_DEFAULT_SIZE: usize = 16 * 1024;
+const BUF_POOLSIZE: usize = 0;
+
+// helper functions
+fn size() -> usize {
+    BUF_DEFAULT_SIZE
+}
+
+fn poolsize() -> usize {
+    BUF_POOLSIZE
+}
+
+// struct definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct BufConfig {
+    #[cfg_attr(feature = "serde", serde(default = "size"))]
+    size: usize,
+    #[cfg_attr(feature = "serde", serde(default = "poolsize"))]
+    poolsize: usize,
+}
+
+// implementation
+impl BufConfig {
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn poolsize(&self) -> usize {
+        self.poolsize
+    }
+}
+
+// trait implementations
+impl Default for BufConfig {
+    fn default() -> Self {
+        Self {
+            size: size(),
+            poolsize: poolsize(),
+        }
+    }
+}

--- a/rust/ccommon-buffer/src/dbuf/mod.rs
+++ b/rust/ccommon-buffer/src/dbuf/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const DBUF_DEFAULT_MAX: usize = 8;
+
+// helper functions
+fn max_power() -> usize {
+    DBUF_DEFAULT_MAX
+}
+
+// struct definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DbufConfig {
+    #[cfg_attr(feature = "serde", serde(default = "max_power"))]
+    max_power: usize,
+}
+
+// implementation
+impl DbufConfig {
+    pub fn max_power(&self) -> usize {
+        self.max_power
+    }
+}
+
+// trait implementations
+impl Default for DbufConfig {
+    fn default() -> Self {
+        Self {
+            max_power: max_power(),
+        }
+    }
+}

--- a/rust/ccommon-buffer/src/lib.rs
+++ b/rust/ccommon-buffer/src/lib.rs
@@ -1,0 +1,9 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+mod buf;
+mod dbuf;
+
+pub use buf::*;
+pub use dbuf::*;

--- a/rust/ccommon-channel/CMakeLists.txt
+++ b/rust/ccommon-channel/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+cargo_build(NAME ccommon-channel)

--- a/rust/ccommon-channel/Cargo.toml
+++ b/rust/ccommon-channel/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ccommon-channel"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.110", features = ["derive"], optional = true }
+
+[features]
+default = [ "serde/derive" ]

--- a/rust/ccommon-channel/src/lib.rs
+++ b/rust/ccommon-channel/src/lib.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const TCP_BACKLOG: usize = 128;
+const TCP_POOLSIZE: usize = 0;
+
+// helper functions
+fn backlog() -> usize {
+    TCP_BACKLOG
+}
+
+fn poolsize() -> usize {
+    TCP_POOLSIZE
+}
+
+// definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TcpConfig {
+	#[cfg_attr(feature = "serde", serde(default = "backlog"))]
+    backlog: usize,
+    #[cfg_attr(feature = "serde", serde(default = "poolsize"))]
+    poolsize: usize,
+}
+
+// implementation
+impl TcpConfig {
+    pub fn backlog(&self) -> usize {
+        self.backlog
+    }
+
+    pub fn poolsize(&self) -> usize {
+        self.poolsize
+    }
+}
+
+// trait implementations
+impl Default for TcpConfig {
+    fn default() -> Self {
+        Self {
+            backlog: backlog(),
+            poolsize: poolsize(),
+        }
+    }
+}

--- a/rust/ccommon-log/CMakeLists.txt
+++ b/rust/ccommon-log/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+cargo_build(NAME ccommon-log)

--- a/rust/ccommon-log/Cargo.toml
+++ b/rust/ccommon-log/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ccommon-log"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.110", features = ["derive"], optional = true }
+
+[features]
+default = [ "serde/derive" ]
+

--- a/rust/ccommon-log/src/lib.rs
+++ b/rust/ccommon-log/src/lib.rs
@@ -1,0 +1,62 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const DEBUG_LOG_LEVEL: usize = 4;
+const DEBUG_LOG_FILE: Option<String> = None;
+const DEBUG_LOG_NBUF: usize = 0;
+
+// helper functions
+fn log_level() -> usize {
+    DEBUG_LOG_LEVEL
+}
+
+fn log_file() -> Option<String> {
+    DEBUG_LOG_FILE
+}
+
+fn log_nbuf() -> usize {
+    DEBUG_LOG_NBUF
+}
+
+// struct definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DebugConfig {
+    #[cfg_attr(feature = "serde", serde(default = "log_level"))]
+    log_level: usize,
+    #[cfg_attr(feature = "serde", serde(default = "log_file"))]
+    log_file: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default = "log_nbuf"))]
+    log_nbuf: usize,
+}
+
+// implementation
+impl DebugConfig {
+    pub fn log_level(&self) -> usize {
+        self.log_level
+    }
+
+    pub fn log_file(&self) -> Option<String> {
+        self.log_file.clone()
+    }
+
+    pub fn log_nbuf(&self) -> usize {
+        self.log_nbuf
+    }
+}
+
+// trait implementations
+impl Default for DebugConfig {
+    fn default() -> Self {
+        Self {
+            log_level: log_level(),
+            log_file: log_file(),
+            log_nbuf: log_nbuf(),
+        }
+    }
+}

--- a/rust/ccommon-stats/CMakeLists.txt
+++ b/rust/ccommon-stats/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+cargo_build(NAME ccommon-stats)

--- a/rust/ccommon-stats/Cargo.toml
+++ b/rust/ccommon-stats/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ccommon-stats"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.110", features = ["derive"], optional = true }
+
+[features]
+default = [ "serde/derive" ]
+

--- a/rust/ccommon-stats/src/lib.rs
+++ b/rust/ccommon-stats/src/lib.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const STATS_LOG_FILE: Option<String> = None;
+const STATS_LOG_NBUF: usize = 0;
+
+// helper functions
+fn file() -> Option<String> {
+    STATS_LOG_FILE
+}
+
+fn nbuf() -> usize {
+    STATS_LOG_NBUF
+}
+
+// definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct StatsLogConfig {
+	#[cfg_attr(feature = "serde", serde(default = "file"))]
+    file: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default = "nbuf"))]
+    nbuf: usize,
+}
+
+// implementation
+impl StatsLogConfig {
+    pub fn log_file(&self) -> Option<String> {
+        self.file.clone()
+    }
+
+    pub fn log_nbuf(&self) -> usize {
+        self.nbuf
+    }
+}
+
+// trait implementations
+impl Default for StatsLogConfig {
+    fn default() -> Self {
+        Self {
+            file: file(),
+            nbuf: nbuf(),
+        }
+    }
+}

--- a/rust/ccommon-stream/CMakeLists.txt
+++ b/rust/ccommon-stream/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+cargo_build(NAME ccommon-stream)

--- a/rust/ccommon-stream/Cargo.toml
+++ b/rust/ccommon-stream/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ccommon-stream"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.110", features = ["derive"], optional = true }
+
+[features]
+default = [ "serde/derive" ]
+

--- a/rust/ccommon-stream/src/lib.rs
+++ b/rust/ccommon-stream/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const BUFSOCK_POOLSIZE: usize = 0;
+
+// helper functions
+fn buf_sock_poolsize() -> usize {
+    BUFSOCK_POOLSIZE
+}
+
+// definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SockioConfig {
+	#[cfg_attr(feature = "serde", serde(default = "buf_sock_poolsize"))]
+    buf_sock_poolsize: usize,
+}
+
+// implementation
+impl SockioConfig {
+    pub fn buf_sock_poolsize(&self) -> usize {
+        self.buf_sock_poolsize
+    }
+}
+
+// trait implementations
+impl Default for SockioConfig {
+    fn default() -> Self {
+        Self {
+            buf_sock_poolsize: buf_sock_poolsize(),
+        }
+    }
+}

--- a/rust/ccommon-time/CMakeLists.txt
+++ b/rust/ccommon-time/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+cargo_build(NAME ccommon-time)

--- a/rust/ccommon-time/Cargo.toml
+++ b/rust/ccommon-time/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ccommon-time"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.110", features = ["derive"], optional = true }
+
+[features]
+default = [ "serde/derive" ]
+

--- a/rust/ccommon-time/src/lib.rs
+++ b/rust/ccommon-time/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const DEFAULT_TIME_TYPE: TimeType = TimeType::Unix;
+
+// helper functions
+fn time_type() -> TimeType {
+    DEFAULT_TIME_TYPE
+}
+
+// definitions
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum TimeType {
+    Unix = 0,
+    Delta = 1,
+    Memcache = 2,
+    Sentinel = 3,
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TimeConfig {
+    #[cfg_attr(feature = "serde", serde(default = "time_type"))]
+    time_type: TimeType,
+}
+
+// implementation
+impl TimeConfig {
+    pub fn time_type(&self) -> TimeType {
+        self.time_type
+    }
+}
+
+// trait implementations
+impl Default for TimeConfig {
+    fn default() -> Self {
+        Self {
+            time_type: time_type(),
+        }
+    }
+}


### PR DESCRIPTION
Adds pure rust libraries which contain config structs for the
various ccommon modules. These will be used from pelikan to express
the configuration of parameters for tcp, socket io, buffers, debug,
etc.