### PR TITLE
add pipe config to rust ccommon-channel

### DIFF
--- a/rust/ccommon-channel/src/lib.rs
+++ b/rust/ccommon-channel/src/lib.rs
@@ -2,49 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+mod pipe;
+mod tcp;
 
-// constants to define default values
-const TCP_BACKLOG: usize = 128;
-const TCP_POOLSIZE: usize = 0;
-
-// helper functions
-fn backlog() -> usize {
-    TCP_BACKLOG
-}
-
-fn poolsize() -> usize {
-    TCP_POOLSIZE
-}
-
-// definitions
-#[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct TcpConfig {
-	#[cfg_attr(feature = "serde", serde(default = "backlog"))]
-    backlog: usize,
-    #[cfg_attr(feature = "serde", serde(default = "poolsize"))]
-    poolsize: usize,
-}
-
-// implementation
-impl TcpConfig {
-    pub fn backlog(&self) -> usize {
-        self.backlog
-    }
-
-    pub fn poolsize(&self) -> usize {
-        self.poolsize
-    }
-}
-
-// trait implementations
-impl Default for TcpConfig {
-    fn default() -> Self {
-        Self {
-            backlog: backlog(),
-            poolsize: poolsize(),
-        }
-    }
-}
+pub use pipe::*;
+pub use tcp::*;

--- a/rust/ccommon-channel/src/pipe/mod.rs
+++ b/rust/ccommon-channel/src/pipe/mod.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const TCP_BACKLOG: usize = 128;
+const TCP_POOLSIZE: usize = 0;
+
+// helper functions
+fn backlog() -> usize {
+    TCP_BACKLOG
+}
+
+fn poolsize() -> usize {
+    TCP_POOLSIZE
+}
+
+// definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TcpConfig {
+	#[cfg_attr(feature = "serde", serde(default = "backlog"))]
+    backlog: usize,
+    #[cfg_attr(feature = "serde", serde(default = "poolsize"))]
+    poolsize: usize,
+}
+
+// implementation
+impl TcpConfig {
+    pub fn backlog(&self) -> usize {
+        self.backlog
+    }
+
+    pub fn poolsize(&self) -> usize {
+        self.poolsize
+    }
+}
+
+// trait implementations
+impl Default for TcpConfig {
+    fn default() -> Self {
+        Self {
+            backlog: backlog(),
+            poolsize: poolsize(),
+        }
+    }
+}

--- a/rust/ccommon-channel/src/pipe/mod.rs
+++ b/rust/ccommon-channel/src/pipe/mod.rs
@@ -6,44 +6,32 @@
 use serde::{Deserialize, Serialize};
 
 // constants to define default values
-const TCP_BACKLOG: usize = 128;
-const TCP_POOLSIZE: usize = 0;
+const PIPE_POOLSIZE: usize = 0;
 
 // helper functions
-fn backlog() -> usize {
-    TCP_BACKLOG
-}
-
 fn poolsize() -> usize {
-    TCP_POOLSIZE
+    PIPE_POOLSIZE
 }
 
 // definitions
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct TcpConfig {
-	#[cfg_attr(feature = "serde", serde(default = "backlog"))]
-    backlog: usize,
+pub struct PipeConfig {
     #[cfg_attr(feature = "serde", serde(default = "poolsize"))]
     poolsize: usize,
 }
 
 // implementation
-impl TcpConfig {
-    pub fn backlog(&self) -> usize {
-        self.backlog
-    }
-
+impl PipeConfig {
     pub fn poolsize(&self) -> usize {
         self.poolsize
     }
 }
 
 // trait implementations
-impl Default for TcpConfig {
+impl Default for PipeConfig {
     fn default() -> Self {
         Self {
-            backlog: backlog(),
             poolsize: poolsize(),
         }
     }

--- a/rust/ccommon-channel/src/tcp/mod.rs
+++ b/rust/ccommon-channel/src/tcp/mod.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// constants to define default values
+const TCP_BACKLOG: usize = 128;
+const TCP_POOLSIZE: usize = 0;
+
+// helper functions
+fn backlog() -> usize {
+    TCP_BACKLOG
+}
+
+fn poolsize() -> usize {
+    TCP_POOLSIZE
+}
+
+// definitions
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TcpConfig {
+	#[cfg_attr(feature = "serde", serde(default = "backlog"))]
+    backlog: usize,
+    #[cfg_attr(feature = "serde", serde(default = "poolsize"))]
+    poolsize: usize,
+}
+
+// implementation
+impl TcpConfig {
+    pub fn backlog(&self) -> usize {
+        self.backlog
+    }
+
+    pub fn poolsize(&self) -> usize {
+        self.poolsize
+    }
+}
+
+// trait implementations
+impl Default for TcpConfig {
+    fn default() -> Self {
+        Self {
+            backlog: backlog(),
+            poolsize: poolsize(),
+        }
+    }
+}


### PR DESCRIPTION
Initial implementation was missing the configuration struct for the
pipe channel type.

Adds the config struct and refactors this crate