### PR TITLE
cmake: gen config.h into include to support make install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 # Automatically generated files
 COPYING
 INSTALL
+include/config.h
 
 # Temporary
 *.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ check_function_exists(accept4 HAVE_ACCEPT4)
 # this has to be set _after_ the above checks
 configure_file(
   "${PROJECT_SOURCE_DIR}/config.h.in"
-  "${PROJECT_BINARY_DIR}/config.h")
+  "${PROJECT_SOURCE_DIR}/include/config.h")
 
 
 ##########################


### PR DESCRIPTION
Problem

`make install` does not install config.h with other headers
so it's impossible to just add <include-dir>/ccommon-2.1 dir into include directory path as:

```
➜  ~ g++ m.cpp   -l ccommon -I /usr/local/include/ccommon-2.1 -fpermissive && ./a.out
In file included from /usr/local/include/ccommon-2.1/cc_array.h:24,
                 from m.cpp:2:
/usr/local/include/ccommon-2.1/cc_define.h:24:10: fatal error: config.h: No such file or directory
   24 | #include <config.h>
      |          ^~~~~~~~~~
compilation terminated.
```


Solution

Generate config.h into include directory with other headers

Result

```
-- Installing: /usr/local/include/ccommon-2.1/config.h
```

It's possible to build a binary using:
```
➜  ~ g++ m.cpp   -l ccommon -I /usr/local/include/ccommon-2.1 -fpermissive && ./a.out
DONE%   
```