### PR TITLE
Delete flaky assert within check_tcp

### DIFF
--- a/test/channel/tcp/check_tcp.c
+++ b/test/channel/tcp/check_tcp.c
@@ -333,7 +333,6 @@ START_TEST(test_nonblocking)
     pthread_join(thread, NULL);
 
     ck_assert_int_ge(duration_us(&duration), SLEEP_TIME);
-    ck_assert_int_le(duration_us(&duration), SLEEP_TIME + TOLERANCE_TIME);
 
     tcp_close(conn_listen);
     tcp_close(conn_server);


### PR DESCRIPTION
This assert has been causing issues for CI in pelikan. It also doesn't test what we want it to test since it also measures the latency of starting a new thread in addition to the time that thread spends sleeping. Beyond that, this test has had flakiness issues before and the response each time has been to just bump up the tolerance. That suggests that it's not worth having this assert since everyone will just ignore test failures anyway.

As such, this change removes the assert which should hopefully be enough to avoid downstream test flakiness.
