### PR TITLE
Delete flaky assert within check_pipe

### DIFF
--- a/test/channel/pipe/check_pipe.c
+++ b/test/channel/pipe/check_pipe.c
@@ -128,7 +128,6 @@ START_TEST(test_read_blocking)
     pthread_join(thread, NULL);
 
     ck_assert_int_ge(duration_us(&duration), SLEEP_TIME - TOLERANCE_UNDER);
-    ck_assert_int_le(duration_us(&duration), SLEEP_TIME + TOLERANCE_OVER);
 
     ck_assert_str_eq(write_message, read_message);
 


### PR DESCRIPTION
The motivation for this is similar to that for #253: the latency from
pthread_create makes this fundamentally flaky and the number of times
it fires means that this assert is not worth having.
