### PR TITLE
increase tick interval for cc_wheel tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, macos-10.15 ]
+        profile: [ Release ]
+    name: build-${{ matrix.os }}-${{ matrix.profile }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure
+        run: |
+          mkdir -p _build
+          cmake -B _build -S . \
+            -DCMAKE_BUILD_TYPE=${{ matrix.profile }} \
+            -DBUILD_AND_INSTALL_CHECK=yes
+
+      - name: Build
+        run: |
+          cmake --build _build
+
+      - name: Test
+        run: |
+          cmake --build _build --target test
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1

--- a/test/time/wheel/check_wheel.c
+++ b/test/time/wheel/check_wheel.c
@@ -42,7 +42,7 @@ _incr_cb(void *v)
 
 START_TEST(test_timing_wheel_basic)
 {
-#define TICK_NS 1000000
+#define TICK_NS 100000000
 #define NSLOT 3
 #define NTICK 2
 
@@ -182,7 +182,7 @@ END_TEST
 
 START_TEST(test_timing_wheel_edge_case)
 {
-#define TICK_NS 1000000
+#define TICK_NS 100000000
 #define NSLOT 3
 #define NTICK 2
 


### PR DESCRIPTION
The cc_wheel tests are flakey in CI on GitHub. To address this, we
can increase the tick interval so it is less susceptible to jitter
and timing issues in the CI environment.
